### PR TITLE
fix: improve regex for getClientCompilerName function source

### DIFF
--- a/src/plugin/index.ts
+++ b/src/plugin/index.ts
@@ -28,8 +28,7 @@ export default class MarkoWebpackPlugin {
       this.getClientCompilerNameSource = options.getClientCompilerName.toString();
 
       if (
-        this.getClientCompilerNameSource[0] !== "(" &&
-        !this.getClientCompilerNameSource.startsWith("function ")
+        /^getClientCompilerName\s*\(/.test(this.getClientCompilerNameSource)
       ) {
         this.getClientCompilerNameSource = `function ${
           this.getClientCompilerNameSource


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Uses a more strict regex to determine if the passed function source for `getClientCompilerName` is a shorthand method (which is invalid as an expression and needs `function ` prepended to the source). 

## Motivation and Context

Prior to this change an arrow function without parens (`x => {}`) would have `function` prepended to its source.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.

<!--
Disclaimer: Contributions via GitHub pull requests are gladly accepted from their original author. Along with any pull requests, please state that the contribution is your original work and that you license the work to the project under the project's open source license. Whether or not you state this explicitly, by submitting any copyrighted material via pull request, email, or other means you agree to license the material under the project's open source license and warrant that you have the legal authority to do so.
-->
