### PR TITLE
feat: switch output from loader to use es modules

### DIFF
--- a/src/__tests__/fixtures/basic-template-plugin/__snapshots__/browser--test_uYWJ.js
+++ b/src/__tests__/fixtures/basic-template-plugin/__snapshots__/browser--test_uYWJ.js
@@ -15,15 +15,19 @@
 /*!*************************************************************************!*\
   !*** ./src/__tests__/fixtures/basic-template-plugin/test.marko?hydrate ***!
   \*************************************************************************/
-/*! no static exports found */
-/***/ (function(module, exports, __webpack_require__) {
+/*! no exports provided */
+/***/ (function(module, __webpack_exports__, __webpack_require__) {
 
+"use strict";
+__webpack_require__.r(__webpack_exports__);
+/* harmony import */ var _test_marko_dependencies__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! ./test.marko?dependencies */ "./src/__tests__/fixtures/basic-template-plugin/test.marko?dependencies");
+/* harmony import */ var _test_marko_dependencies__WEBPACK_IMPORTED_MODULE_0___default = /*#__PURE__*/__webpack_require__.n(_test_marko_dependencies__WEBPACK_IMPORTED_MODULE_0__);
 
       if (window.$mwp) {
         __webpack_require__.p = $mwp;
       }
 
-      __webpack_require__(/*! ./test.marko?dependencies */ "./src/__tests__/fixtures/basic-template-plugin/test.marko?dependencies");
+      
       window.$initComponents && window.$initComponents();
     
 

--- a/src/__tests__/fixtures/multiple-entries-plugin/__snapshots__/browser--bar_aSxt.js
+++ b/src/__tests__/fixtures/multiple-entries-plugin/__snapshots__/browser--bar_aSxt.js
@@ -4,10 +4,14 @@
 /*!*******************************************************************************!*\
   !*** ./src/__tests__/fixtures/multiple-entries-plugin/bar.marko?dependencies ***!
   \*******************************************************************************/
-/*! no static exports found */
-/***/ (function(module, exports, __webpack_require__) {
+/*! no exports provided */
+/***/ (function(module, __webpack_exports__, __webpack_require__) {
 
-__webpack_require__(/*! ./components/shared.marko?dependencies */ "./src/__tests__/fixtures/multiple-entries-plugin/components/shared.marko?dependencies");
+"use strict";
+__webpack_require__.r(__webpack_exports__);
+/* harmony import */ var _components_shared_marko_dependencies__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! ./components/shared.marko?dependencies */ "./src/__tests__/fixtures/multiple-entries-plugin/components/shared.marko?dependencies");
+/* harmony import */ var _components_shared_marko_dependencies__WEBPACK_IMPORTED_MODULE_0___default = /*#__PURE__*/__webpack_require__.n(_components_shared_marko_dependencies__WEBPACK_IMPORTED_MODULE_0__);
+
 
 /***/ }),
 
@@ -15,15 +19,18 @@ __webpack_require__(/*! ./components/shared.marko?dependencies */ "./src/__tests
 /*!**************************************************************************!*\
   !*** ./src/__tests__/fixtures/multiple-entries-plugin/bar.marko?hydrate ***!
   \**************************************************************************/
-/*! no static exports found */
-/***/ (function(module, exports, __webpack_require__) {
+/*! no exports provided */
+/***/ (function(module, __webpack_exports__, __webpack_require__) {
 
+"use strict";
+__webpack_require__.r(__webpack_exports__);
+/* harmony import */ var _bar_marko_dependencies__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! ./bar.marko?dependencies */ "./src/__tests__/fixtures/multiple-entries-plugin/bar.marko?dependencies");
 
       if (window.$mwp) {
         __webpack_require__.p = $mwp;
       }
 
-      __webpack_require__(/*! ./bar.marko?dependencies */ "./src/__tests__/fixtures/multiple-entries-plugin/bar.marko?dependencies");
+      
       window.$initComponents && window.$initComponents();
     
 

--- a/src/__tests__/fixtures/multiple-entries-plugin/__snapshots__/browser--foo_3XPO.js
+++ b/src/__tests__/fixtures/multiple-entries-plugin/__snapshots__/browser--foo_3XPO.js
@@ -4,10 +4,14 @@
 /*!*******************************************************************************!*\
   !*** ./src/__tests__/fixtures/multiple-entries-plugin/foo.marko?dependencies ***!
   \*******************************************************************************/
-/*! no static exports found */
-/***/ (function(module, exports, __webpack_require__) {
+/*! no exports provided */
+/***/ (function(module, __webpack_exports__, __webpack_require__) {
 
-__webpack_require__(/*! ./components/shared.marko?dependencies */ "./src/__tests__/fixtures/multiple-entries-plugin/components/shared.marko?dependencies");
+"use strict";
+__webpack_require__.r(__webpack_exports__);
+/* harmony import */ var _components_shared_marko_dependencies__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! ./components/shared.marko?dependencies */ "./src/__tests__/fixtures/multiple-entries-plugin/components/shared.marko?dependencies");
+/* harmony import */ var _components_shared_marko_dependencies__WEBPACK_IMPORTED_MODULE_0___default = /*#__PURE__*/__webpack_require__.n(_components_shared_marko_dependencies__WEBPACK_IMPORTED_MODULE_0__);
+
 
 /***/ }),
 
@@ -15,15 +19,18 @@ __webpack_require__(/*! ./components/shared.marko?dependencies */ "./src/__tests
 /*!**************************************************************************!*\
   !*** ./src/__tests__/fixtures/multiple-entries-plugin/foo.marko?hydrate ***!
   \**************************************************************************/
-/*! no static exports found */
-/***/ (function(module, exports, __webpack_require__) {
+/*! no exports provided */
+/***/ (function(module, __webpack_exports__, __webpack_require__) {
 
+"use strict";
+__webpack_require__.r(__webpack_exports__);
+/* harmony import */ var _foo_marko_dependencies__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! ./foo.marko?dependencies */ "./src/__tests__/fixtures/multiple-entries-plugin/foo.marko?dependencies");
 
       if (window.$mwp) {
         __webpack_require__.p = $mwp;
       }
 
-      __webpack_require__(/*! ./foo.marko?dependencies */ "./src/__tests__/fixtures/multiple-entries-plugin/foo.marko?dependencies");
+      
       window.$initComponents && window.$initComponents();
     
 

--- a/src/__tests__/fixtures/with-class-component-plugin-dynamic-bundle/__snapshots__/browser-A--test_YDNP.A.js
+++ b/src/__tests__/fixtures/with-class-component-plugin-dynamic-bundle/__snapshots__/browser-A--test_YDNP.A.js
@@ -1,13 +1,52 @@
 /******/ ({
 
+/***/ "./node_modules/webpack/buildin/harmony-module.js":
+/*!*******************************************!*\
+  !*** (webpack)/buildin/harmony-module.js ***!
+  \*******************************************/
+/*! no static exports found */
+/***/ (function(module, exports) {
+
+module.exports = function(originalModule) {
+	if (!originalModule.webpackPolyfill) {
+		var module = Object.create(originalModule);
+		// module.parent = undefined by default
+		if (!module.children) module.children = [];
+		Object.defineProperty(module, "loaded", {
+			enumerable: true,
+			get: function() {
+				return module.l;
+			}
+		});
+		Object.defineProperty(module, "id", {
+			enumerable: true,
+			get: function() {
+				return module.i;
+			}
+		});
+		Object.defineProperty(module, "exports", {
+			enumerable: true
+		});
+		module.webpackPolyfill = 1;
+	}
+	return module;
+};
+
+
+/***/ }),
+
 /***/ "./src/__tests__/fixtures/with-class-component-plugin-dynamic-bundle/components/nested/index.marko":
 /*!*********************************************************************************************************!*\
   !*** ./src/__tests__/fixtures/with-class-component-plugin-dynamic-bundle/components/nested/index.marko ***!
   \*********************************************************************************************************/
-/*! no static exports found */
-/***/ (function(module, exports, __webpack_require__) {
+/*! no exports provided */
+/***/ (function(module, __webpack_exports__, __webpack_require__) {
 
-__webpack_require__(/*! ./style.css */ "./src/__tests__/fixtures/with-class-component-plugin-dynamic-bundle/components/nested/style.css");
+"use strict";
+__webpack_require__.r(__webpack_exports__);
+/* WEBPACK VAR INJECTION */(function(module) {/* harmony import */ var _style_css__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! ./style.css */ "./src/__tests__/fixtures/with-class-component-plugin-dynamic-bundle/components/nested/style.css");
+/* harmony import */ var _style_css__WEBPACK_IMPORTED_MODULE_0___default = /*#__PURE__*/__webpack_require__.n(_style_css__WEBPACK_IMPORTED_MODULE_0__);
+
 "use strict";
 
 var marko_template = module.exports = __webpack_require__(/*! marko/dist/vdom */ "marko/dist/vdom").t(),
@@ -42,6 +81,7 @@ marko_template._ = marko_renderer(render, {
 
 marko_template.Component = marko_defineComponent(marko_component, marko_template._);
 
+/* WEBPACK VAR INJECTION */}.call(this, __webpack_require__(/*! ./../../../../../../node_modules/webpack/buildin/harmony-module.js */ "./node_modules/webpack/buildin/harmony-module.js")(module)))
 
 /***/ }),
 
@@ -49,16 +89,22 @@ marko_template.Component = marko_defineComponent(marko_component, marko_template
 /*!**********************************************************************************************************************!*\
   !*** ./src/__tests__/fixtures/with-class-component-plugin-dynamic-bundle/components/nested/index.marko?dependencies ***!
   \**********************************************************************************************************************/
-/*! no static exports found */
-/***/ (function(module, exports, __webpack_require__) {
+/*! no exports provided */
+/***/ (function(module, __webpack_exports__, __webpack_require__) {
 
+"use strict";
+__webpack_require__.r(__webpack_exports__);
+/* harmony import */ var marko_components__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! marko/components */ "marko/components");
+/* harmony import */ var marko_components__WEBPACK_IMPORTED_MODULE_0___default = /*#__PURE__*/__webpack_require__.n(marko_components__WEBPACK_IMPORTED_MODULE_0__);
+/* harmony import */ var _index_marko__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(/*! ./index.marko */ "./src/__tests__/fixtures/with-class-component-plugin-dynamic-bundle/components/nested/index.marko");
+/* harmony import */ var _style_css__WEBPACK_IMPORTED_MODULE_2__ = __webpack_require__(/*! ./style.css */ "./src/__tests__/fixtures/with-class-component-plugin-dynamic-bundle/components/nested/style.css");
+/* harmony import */ var _style_css__WEBPACK_IMPORTED_MODULE_2___default = /*#__PURE__*/__webpack_require__.n(_style_css__WEBPACK_IMPORTED_MODULE_2__);
 
-        __webpack_require__(/*! marko/components */ "marko/components").register(
-          "/@marko/webpack-tests$x.x.x/fixtures/with-class-component-plugin-dynamic-bundle/components/nested/index.marko",
-          __webpack_require__(/*! ./index.marko */ "./src/__tests__/fixtures/with-class-component-plugin-dynamic-bundle/components/nested/index.marko")
-        );
       
-__webpack_require__(/*! ./style.css */ "./src/__tests__/fixtures/with-class-component-plugin-dynamic-bundle/components/nested/style.css");
+      
+      Object(marko_components__WEBPACK_IMPORTED_MODULE_0__["register"])("/@marko/webpack-tests$x.x.x/fixtures/with-class-component-plugin-dynamic-bundle/components/nested/index.marko", _index_marko__WEBPACK_IMPORTED_MODULE_1__["default"]);
+      
+
 
 /***/ }),
 
@@ -88,11 +134,16 @@ __webpack_require__(/*! ./style.css */ "./src/__tests__/fixtures/with-class-comp
 /*!***************************************************************************************************!*\
   !*** ./src/__tests__/fixtures/with-class-component-plugin-dynamic-bundle/test.marko?dependencies ***!
   \***************************************************************************************************/
-/*! no static exports found */
-/***/ (function(module, exports, __webpack_require__) {
+/*! no exports provided */
+/***/ (function(module, __webpack_exports__, __webpack_require__) {
 
-__webpack_require__(/*! ./test.marko.css */ "./src/__tests__/fixtures/with-class-component-plugin-dynamic-bundle/test.marko.css")
-__webpack_require__(/*! ./components/nested/index.marko?dependencies */ "./src/__tests__/fixtures/with-class-component-plugin-dynamic-bundle/components/nested/index.marko?dependencies");
+"use strict";
+__webpack_require__.r(__webpack_exports__);
+/* harmony import */ var _test_marko_css__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! ./test.marko.css */ "./src/__tests__/fixtures/with-class-component-plugin-dynamic-bundle/test.marko.css");
+/* harmony import */ var _test_marko_css__WEBPACK_IMPORTED_MODULE_0___default = /*#__PURE__*/__webpack_require__.n(_test_marko_css__WEBPACK_IMPORTED_MODULE_0__);
+/* harmony import */ var _components_nested_index_marko_dependencies__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(/*! ./components/nested/index.marko?dependencies */ "./src/__tests__/fixtures/with-class-component-plugin-dynamic-bundle/components/nested/index.marko?dependencies");
+
+
 
 /***/ }),
 
@@ -100,15 +151,18 @@ __webpack_require__(/*! ./components/nested/index.marko?dependencies */ "./src/_
 /*!**********************************************************************************************!*\
   !*** ./src/__tests__/fixtures/with-class-component-plugin-dynamic-bundle/test.marko?hydrate ***!
   \**********************************************************************************************/
-/*! no static exports found */
-/***/ (function(module, exports, __webpack_require__) {
+/*! no exports provided */
+/***/ (function(module, __webpack_exports__, __webpack_require__) {
 
+"use strict";
+__webpack_require__.r(__webpack_exports__);
+/* harmony import */ var _test_marko_dependencies__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! ./test.marko?dependencies */ "./src/__tests__/fixtures/with-class-component-plugin-dynamic-bundle/test.marko?dependencies");
 
       if (window.$mwp) {
         __webpack_require__.p = $mwp;
       }
 
-      __webpack_require__(/*! ./test.marko?dependencies */ "./src/__tests__/fixtures/with-class-component-plugin-dynamic-bundle/test.marko?dependencies");
+      
       window.$initComponents && window.$initComponents();
     
 

--- a/src/__tests__/fixtures/with-class-component-plugin-dynamic-bundle/__snapshots__/browser-B--test_YDNP.B.js
+++ b/src/__tests__/fixtures/with-class-component-plugin-dynamic-bundle/__snapshots__/browser-B--test_YDNP.B.js
@@ -1,13 +1,52 @@
 /******/ ({
 
+/***/ "./node_modules/webpack/buildin/harmony-module.js":
+/*!*******************************************!*\
+  !*** (webpack)/buildin/harmony-module.js ***!
+  \*******************************************/
+/*! no static exports found */
+/***/ (function(module, exports) {
+
+module.exports = function(originalModule) {
+	if (!originalModule.webpackPolyfill) {
+		var module = Object.create(originalModule);
+		// module.parent = undefined by default
+		if (!module.children) module.children = [];
+		Object.defineProperty(module, "loaded", {
+			enumerable: true,
+			get: function() {
+				return module.l;
+			}
+		});
+		Object.defineProperty(module, "id", {
+			enumerable: true,
+			get: function() {
+				return module.i;
+			}
+		});
+		Object.defineProperty(module, "exports", {
+			enumerable: true
+		});
+		module.webpackPolyfill = 1;
+	}
+	return module;
+};
+
+
+/***/ }),
+
 /***/ "./src/__tests__/fixtures/with-class-component-plugin-dynamic-bundle/components/nested/index.marko":
 /*!*********************************************************************************************************!*\
   !*** ./src/__tests__/fixtures/with-class-component-plugin-dynamic-bundle/components/nested/index.marko ***!
   \*********************************************************************************************************/
-/*! no static exports found */
-/***/ (function(module, exports, __webpack_require__) {
+/*! no exports provided */
+/***/ (function(module, __webpack_exports__, __webpack_require__) {
 
-__webpack_require__(/*! ./style.css */ "./src/__tests__/fixtures/with-class-component-plugin-dynamic-bundle/components/nested/style.css");
+"use strict";
+__webpack_require__.r(__webpack_exports__);
+/* WEBPACK VAR INJECTION */(function(module) {/* harmony import */ var _style_css__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! ./style.css */ "./src/__tests__/fixtures/with-class-component-plugin-dynamic-bundle/components/nested/style.css");
+/* harmony import */ var _style_css__WEBPACK_IMPORTED_MODULE_0___default = /*#__PURE__*/__webpack_require__.n(_style_css__WEBPACK_IMPORTED_MODULE_0__);
+
 "use strict";
 
 var marko_template = module.exports = __webpack_require__(/*! marko/dist/vdom */ "marko/dist/vdom").t(),
@@ -42,6 +81,7 @@ marko_template._ = marko_renderer(render, {
 
 marko_template.Component = marko_defineComponent(marko_component, marko_template._);
 
+/* WEBPACK VAR INJECTION */}.call(this, __webpack_require__(/*! ./../../../../../../node_modules/webpack/buildin/harmony-module.js */ "./node_modules/webpack/buildin/harmony-module.js")(module)))
 
 /***/ }),
 
@@ -49,16 +89,22 @@ marko_template.Component = marko_defineComponent(marko_component, marko_template
 /*!**********************************************************************************************************************!*\
   !*** ./src/__tests__/fixtures/with-class-component-plugin-dynamic-bundle/components/nested/index.marko?dependencies ***!
   \**********************************************************************************************************************/
-/*! no static exports found */
-/***/ (function(module, exports, __webpack_require__) {
+/*! no exports provided */
+/***/ (function(module, __webpack_exports__, __webpack_require__) {
 
+"use strict";
+__webpack_require__.r(__webpack_exports__);
+/* harmony import */ var marko_components__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! marko/components */ "marko/components");
+/* harmony import */ var marko_components__WEBPACK_IMPORTED_MODULE_0___default = /*#__PURE__*/__webpack_require__.n(marko_components__WEBPACK_IMPORTED_MODULE_0__);
+/* harmony import */ var _index_marko__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(/*! ./index.marko */ "./src/__tests__/fixtures/with-class-component-plugin-dynamic-bundle/components/nested/index.marko");
+/* harmony import */ var _style_css__WEBPACK_IMPORTED_MODULE_2__ = __webpack_require__(/*! ./style.css */ "./src/__tests__/fixtures/with-class-component-plugin-dynamic-bundle/components/nested/style.css");
+/* harmony import */ var _style_css__WEBPACK_IMPORTED_MODULE_2___default = /*#__PURE__*/__webpack_require__.n(_style_css__WEBPACK_IMPORTED_MODULE_2__);
 
-        __webpack_require__(/*! marko/components */ "marko/components").register(
-          "/@marko/webpack-tests$x.x.x/fixtures/with-class-component-plugin-dynamic-bundle/components/nested/index.marko",
-          __webpack_require__(/*! ./index.marko */ "./src/__tests__/fixtures/with-class-component-plugin-dynamic-bundle/components/nested/index.marko")
-        );
       
-__webpack_require__(/*! ./style.css */ "./src/__tests__/fixtures/with-class-component-plugin-dynamic-bundle/components/nested/style.css");
+      
+      Object(marko_components__WEBPACK_IMPORTED_MODULE_0__["register"])("/@marko/webpack-tests$x.x.x/fixtures/with-class-component-plugin-dynamic-bundle/components/nested/index.marko", _index_marko__WEBPACK_IMPORTED_MODULE_1__["default"]);
+      
+
 
 /***/ }),
 
@@ -88,11 +134,16 @@ __webpack_require__(/*! ./style.css */ "./src/__tests__/fixtures/with-class-comp
 /*!***************************************************************************************************!*\
   !*** ./src/__tests__/fixtures/with-class-component-plugin-dynamic-bundle/test.marko?dependencies ***!
   \***************************************************************************************************/
-/*! no static exports found */
-/***/ (function(module, exports, __webpack_require__) {
+/*! no exports provided */
+/***/ (function(module, __webpack_exports__, __webpack_require__) {
 
-__webpack_require__(/*! ./test.marko.css */ "./src/__tests__/fixtures/with-class-component-plugin-dynamic-bundle/test.marko.css")
-__webpack_require__(/*! ./components/nested/index.marko?dependencies */ "./src/__tests__/fixtures/with-class-component-plugin-dynamic-bundle/components/nested/index.marko?dependencies");
+"use strict";
+__webpack_require__.r(__webpack_exports__);
+/* harmony import */ var _test_marko_css__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! ./test.marko.css */ "./src/__tests__/fixtures/with-class-component-plugin-dynamic-bundle/test.marko.css");
+/* harmony import */ var _test_marko_css__WEBPACK_IMPORTED_MODULE_0___default = /*#__PURE__*/__webpack_require__.n(_test_marko_css__WEBPACK_IMPORTED_MODULE_0__);
+/* harmony import */ var _components_nested_index_marko_dependencies__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(/*! ./components/nested/index.marko?dependencies */ "./src/__tests__/fixtures/with-class-component-plugin-dynamic-bundle/components/nested/index.marko?dependencies");
+
+
 
 /***/ }),
 
@@ -100,15 +151,18 @@ __webpack_require__(/*! ./components/nested/index.marko?dependencies */ "./src/_
 /*!**********************************************************************************************!*\
   !*** ./src/__tests__/fixtures/with-class-component-plugin-dynamic-bundle/test.marko?hydrate ***!
   \**********************************************************************************************/
-/*! no static exports found */
-/***/ (function(module, exports, __webpack_require__) {
+/*! no exports provided */
+/***/ (function(module, __webpack_exports__, __webpack_require__) {
 
+"use strict";
+__webpack_require__.r(__webpack_exports__);
+/* harmony import */ var _test_marko_dependencies__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! ./test.marko?dependencies */ "./src/__tests__/fixtures/with-class-component-plugin-dynamic-bundle/test.marko?dependencies");
 
       if (window.$mwp) {
         __webpack_require__.p = $mwp;
       }
 
-      __webpack_require__(/*! ./test.marko?dependencies */ "./src/__tests__/fixtures/with-class-component-plugin-dynamic-bundle/test.marko?dependencies");
+      
       window.$initComponents && window.$initComponents();
     
 

--- a/src/__tests__/fixtures/with-class-component-plugin-dynamic-bundle/__snapshots__/browser-C--test_YDNP.C.js
+++ b/src/__tests__/fixtures/with-class-component-plugin-dynamic-bundle/__snapshots__/browser-C--test_YDNP.C.js
@@ -1,13 +1,52 @@
 /******/ ({
 
+/***/ "./node_modules/webpack/buildin/harmony-module.js":
+/*!*******************************************!*\
+  !*** (webpack)/buildin/harmony-module.js ***!
+  \*******************************************/
+/*! no static exports found */
+/***/ (function(module, exports) {
+
+module.exports = function(originalModule) {
+	if (!originalModule.webpackPolyfill) {
+		var module = Object.create(originalModule);
+		// module.parent = undefined by default
+		if (!module.children) module.children = [];
+		Object.defineProperty(module, "loaded", {
+			enumerable: true,
+			get: function() {
+				return module.l;
+			}
+		});
+		Object.defineProperty(module, "id", {
+			enumerable: true,
+			get: function() {
+				return module.i;
+			}
+		});
+		Object.defineProperty(module, "exports", {
+			enumerable: true
+		});
+		module.webpackPolyfill = 1;
+	}
+	return module;
+};
+
+
+/***/ }),
+
 /***/ "./src/__tests__/fixtures/with-class-component-plugin-dynamic-bundle/components/nested/index.marko":
 /*!*********************************************************************************************************!*\
   !*** ./src/__tests__/fixtures/with-class-component-plugin-dynamic-bundle/components/nested/index.marko ***!
   \*********************************************************************************************************/
-/*! no static exports found */
-/***/ (function(module, exports, __webpack_require__) {
+/*! no exports provided */
+/***/ (function(module, __webpack_exports__, __webpack_require__) {
 
-__webpack_require__(/*! ./style.css */ "./src/__tests__/fixtures/with-class-component-plugin-dynamic-bundle/components/nested/style.css");
+"use strict";
+__webpack_require__.r(__webpack_exports__);
+/* WEBPACK VAR INJECTION */(function(module) {/* harmony import */ var _style_css__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! ./style.css */ "./src/__tests__/fixtures/with-class-component-plugin-dynamic-bundle/components/nested/style.css");
+/* harmony import */ var _style_css__WEBPACK_IMPORTED_MODULE_0___default = /*#__PURE__*/__webpack_require__.n(_style_css__WEBPACK_IMPORTED_MODULE_0__);
+
 "use strict";
 
 var marko_template = module.exports = __webpack_require__(/*! marko/dist/vdom */ "marko/dist/vdom").t(),
@@ -42,6 +81,7 @@ marko_template._ = marko_renderer(render, {
 
 marko_template.Component = marko_defineComponent(marko_component, marko_template._);
 
+/* WEBPACK VAR INJECTION */}.call(this, __webpack_require__(/*! ./../../../../../../node_modules/webpack/buildin/harmony-module.js */ "./node_modules/webpack/buildin/harmony-module.js")(module)))
 
 /***/ }),
 
@@ -49,16 +89,22 @@ marko_template.Component = marko_defineComponent(marko_component, marko_template
 /*!**********************************************************************************************************************!*\
   !*** ./src/__tests__/fixtures/with-class-component-plugin-dynamic-bundle/components/nested/index.marko?dependencies ***!
   \**********************************************************************************************************************/
-/*! no static exports found */
-/***/ (function(module, exports, __webpack_require__) {
+/*! no exports provided */
+/***/ (function(module, __webpack_exports__, __webpack_require__) {
 
+"use strict";
+__webpack_require__.r(__webpack_exports__);
+/* harmony import */ var marko_components__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! marko/components */ "marko/components");
+/* harmony import */ var marko_components__WEBPACK_IMPORTED_MODULE_0___default = /*#__PURE__*/__webpack_require__.n(marko_components__WEBPACK_IMPORTED_MODULE_0__);
+/* harmony import */ var _index_marko__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(/*! ./index.marko */ "./src/__tests__/fixtures/with-class-component-plugin-dynamic-bundle/components/nested/index.marko");
+/* harmony import */ var _style_css__WEBPACK_IMPORTED_MODULE_2__ = __webpack_require__(/*! ./style.css */ "./src/__tests__/fixtures/with-class-component-plugin-dynamic-bundle/components/nested/style.css");
+/* harmony import */ var _style_css__WEBPACK_IMPORTED_MODULE_2___default = /*#__PURE__*/__webpack_require__.n(_style_css__WEBPACK_IMPORTED_MODULE_2__);
 
-        __webpack_require__(/*! marko/components */ "marko/components").register(
-          "/@marko/webpack-tests$x.x.x/fixtures/with-class-component-plugin-dynamic-bundle/components/nested/index.marko",
-          __webpack_require__(/*! ./index.marko */ "./src/__tests__/fixtures/with-class-component-plugin-dynamic-bundle/components/nested/index.marko")
-        );
       
-__webpack_require__(/*! ./style.css */ "./src/__tests__/fixtures/with-class-component-plugin-dynamic-bundle/components/nested/style.css");
+      
+      Object(marko_components__WEBPACK_IMPORTED_MODULE_0__["register"])("/@marko/webpack-tests$x.x.x/fixtures/with-class-component-plugin-dynamic-bundle/components/nested/index.marko", _index_marko__WEBPACK_IMPORTED_MODULE_1__["default"]);
+      
+
 
 /***/ }),
 
@@ -88,11 +134,16 @@ __webpack_require__(/*! ./style.css */ "./src/__tests__/fixtures/with-class-comp
 /*!***************************************************************************************************!*\
   !*** ./src/__tests__/fixtures/with-class-component-plugin-dynamic-bundle/test.marko?dependencies ***!
   \***************************************************************************************************/
-/*! no static exports found */
-/***/ (function(module, exports, __webpack_require__) {
+/*! no exports provided */
+/***/ (function(module, __webpack_exports__, __webpack_require__) {
 
-__webpack_require__(/*! ./test.marko.css */ "./src/__tests__/fixtures/with-class-component-plugin-dynamic-bundle/test.marko.css")
-__webpack_require__(/*! ./components/nested/index.marko?dependencies */ "./src/__tests__/fixtures/with-class-component-plugin-dynamic-bundle/components/nested/index.marko?dependencies");
+"use strict";
+__webpack_require__.r(__webpack_exports__);
+/* harmony import */ var _test_marko_css__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! ./test.marko.css */ "./src/__tests__/fixtures/with-class-component-plugin-dynamic-bundle/test.marko.css");
+/* harmony import */ var _test_marko_css__WEBPACK_IMPORTED_MODULE_0___default = /*#__PURE__*/__webpack_require__.n(_test_marko_css__WEBPACK_IMPORTED_MODULE_0__);
+/* harmony import */ var _components_nested_index_marko_dependencies__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(/*! ./components/nested/index.marko?dependencies */ "./src/__tests__/fixtures/with-class-component-plugin-dynamic-bundle/components/nested/index.marko?dependencies");
+
+
 
 /***/ }),
 
@@ -100,15 +151,18 @@ __webpack_require__(/*! ./components/nested/index.marko?dependencies */ "./src/_
 /*!**********************************************************************************************!*\
   !*** ./src/__tests__/fixtures/with-class-component-plugin-dynamic-bundle/test.marko?hydrate ***!
   \**********************************************************************************************/
-/*! no static exports found */
-/***/ (function(module, exports, __webpack_require__) {
+/*! no exports provided */
+/***/ (function(module, __webpack_exports__, __webpack_require__) {
 
+"use strict";
+__webpack_require__.r(__webpack_exports__);
+/* harmony import */ var _test_marko_dependencies__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! ./test.marko?dependencies */ "./src/__tests__/fixtures/with-class-component-plugin-dynamic-bundle/test.marko?dependencies");
 
       if (window.$mwp) {
         __webpack_require__.p = $mwp;
       }
 
-      __webpack_require__(/*! ./test.marko?dependencies */ "./src/__tests__/fixtures/with-class-component-plugin-dynamic-bundle/test.marko?dependencies");
+      
       window.$initComponents && window.$initComponents();
     
 

--- a/src/__tests__/fixtures/with-class-component-plugin/__snapshots__/browser--test_nzzJ.js
+++ b/src/__tests__/fixtures/with-class-component-plugin/__snapshots__/browser--test_nzzJ.js
@@ -1,13 +1,52 @@
 /******/ ({
 
+/***/ "./node_modules/webpack/buildin/harmony-module.js":
+/*!*******************************************!*\
+  !*** (webpack)/buildin/harmony-module.js ***!
+  \*******************************************/
+/*! no static exports found */
+/***/ (function(module, exports) {
+
+module.exports = function(originalModule) {
+	if (!originalModule.webpackPolyfill) {
+		var module = Object.create(originalModule);
+		// module.parent = undefined by default
+		if (!module.children) module.children = [];
+		Object.defineProperty(module, "loaded", {
+			enumerable: true,
+			get: function() {
+				return module.l;
+			}
+		});
+		Object.defineProperty(module, "id", {
+			enumerable: true,
+			get: function() {
+				return module.i;
+			}
+		});
+		Object.defineProperty(module, "exports", {
+			enumerable: true
+		});
+		module.webpackPolyfill = 1;
+	}
+	return module;
+};
+
+
+/***/ }),
+
 /***/ "./src/__tests__/fixtures/with-class-component-plugin/components/nested/index.marko":
 /*!******************************************************************************************!*\
   !*** ./src/__tests__/fixtures/with-class-component-plugin/components/nested/index.marko ***!
   \******************************************************************************************/
-/*! no static exports found */
-/***/ (function(module, exports, __webpack_require__) {
+/*! no exports provided */
+/***/ (function(module, __webpack_exports__, __webpack_require__) {
 
-__webpack_require__(/*! ./style.css */ "./src/__tests__/fixtures/with-class-component-plugin/components/nested/style.css");
+"use strict";
+__webpack_require__.r(__webpack_exports__);
+/* WEBPACK VAR INJECTION */(function(module) {/* harmony import */ var _style_css__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! ./style.css */ "./src/__tests__/fixtures/with-class-component-plugin/components/nested/style.css");
+/* harmony import */ var _style_css__WEBPACK_IMPORTED_MODULE_0___default = /*#__PURE__*/__webpack_require__.n(_style_css__WEBPACK_IMPORTED_MODULE_0__);
+
 "use strict";
 
 var marko_template = module.exports = __webpack_require__(/*! marko/dist/vdom */ "marko/dist/vdom").t(),
@@ -40,6 +79,7 @@ marko_template._ = marko_renderer(render, {
 
 marko_template.Component = marko_defineComponent(marko_component, marko_template._);
 
+/* WEBPACK VAR INJECTION */}.call(this, __webpack_require__(/*! ./../../../../../../node_modules/webpack/buildin/harmony-module.js */ "./node_modules/webpack/buildin/harmony-module.js")(module)))
 
 /***/ }),
 
@@ -47,16 +87,22 @@ marko_template.Component = marko_defineComponent(marko_component, marko_template
 /*!*******************************************************************************************************!*\
   !*** ./src/__tests__/fixtures/with-class-component-plugin/components/nested/index.marko?dependencies ***!
   \*******************************************************************************************************/
-/*! no static exports found */
-/***/ (function(module, exports, __webpack_require__) {
+/*! no exports provided */
+/***/ (function(module, __webpack_exports__, __webpack_require__) {
 
+"use strict";
+__webpack_require__.r(__webpack_exports__);
+/* harmony import */ var marko_components__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! marko/components */ "marko/components");
+/* harmony import */ var marko_components__WEBPACK_IMPORTED_MODULE_0___default = /*#__PURE__*/__webpack_require__.n(marko_components__WEBPACK_IMPORTED_MODULE_0__);
+/* harmony import */ var _index_marko__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(/*! ./index.marko */ "./src/__tests__/fixtures/with-class-component-plugin/components/nested/index.marko");
+/* harmony import */ var _style_css__WEBPACK_IMPORTED_MODULE_2__ = __webpack_require__(/*! ./style.css */ "./src/__tests__/fixtures/with-class-component-plugin/components/nested/style.css");
+/* harmony import */ var _style_css__WEBPACK_IMPORTED_MODULE_2___default = /*#__PURE__*/__webpack_require__.n(_style_css__WEBPACK_IMPORTED_MODULE_2__);
 
-        __webpack_require__(/*! marko/components */ "marko/components").register(
-          "/@marko/webpack-tests$x.x.x/fixtures/with-class-component-plugin/components/nested/index.marko",
-          __webpack_require__(/*! ./index.marko */ "./src/__tests__/fixtures/with-class-component-plugin/components/nested/index.marko")
-        );
       
-__webpack_require__(/*! ./style.css */ "./src/__tests__/fixtures/with-class-component-plugin/components/nested/style.css");
+      
+      Object(marko_components__WEBPACK_IMPORTED_MODULE_0__["register"])("/@marko/webpack-tests$x.x.x/fixtures/with-class-component-plugin/components/nested/index.marko", _index_marko__WEBPACK_IMPORTED_MODULE_1__["default"]);
+      
+
 
 /***/ }),
 
@@ -86,11 +132,16 @@ __webpack_require__(/*! ./style.css */ "./src/__tests__/fixtures/with-class-comp
 /*!************************************************************************************!*\
   !*** ./src/__tests__/fixtures/with-class-component-plugin/test.marko?dependencies ***!
   \************************************************************************************/
-/*! no static exports found */
-/***/ (function(module, exports, __webpack_require__) {
+/*! no exports provided */
+/***/ (function(module, __webpack_exports__, __webpack_require__) {
 
-__webpack_require__(/*! ./test.marko.css */ "./src/__tests__/fixtures/with-class-component-plugin/test.marko.css")
-__webpack_require__(/*! ./components/nested/index.marko?dependencies */ "./src/__tests__/fixtures/with-class-component-plugin/components/nested/index.marko?dependencies");
+"use strict";
+__webpack_require__.r(__webpack_exports__);
+/* harmony import */ var _test_marko_css__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! ./test.marko.css */ "./src/__tests__/fixtures/with-class-component-plugin/test.marko.css");
+/* harmony import */ var _test_marko_css__WEBPACK_IMPORTED_MODULE_0___default = /*#__PURE__*/__webpack_require__.n(_test_marko_css__WEBPACK_IMPORTED_MODULE_0__);
+/* harmony import */ var _components_nested_index_marko_dependencies__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(/*! ./components/nested/index.marko?dependencies */ "./src/__tests__/fixtures/with-class-component-plugin/components/nested/index.marko?dependencies");
+
+
 
 /***/ }),
 
@@ -98,15 +149,18 @@ __webpack_require__(/*! ./components/nested/index.marko?dependencies */ "./src/_
 /*!*******************************************************************************!*\
   !*** ./src/__tests__/fixtures/with-class-component-plugin/test.marko?hydrate ***!
   \*******************************************************************************/
-/*! no static exports found */
-/***/ (function(module, exports, __webpack_require__) {
+/*! no exports provided */
+/***/ (function(module, __webpack_exports__, __webpack_require__) {
 
+"use strict";
+__webpack_require__.r(__webpack_exports__);
+/* harmony import */ var _test_marko_dependencies__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! ./test.marko?dependencies */ "./src/__tests__/fixtures/with-class-component-plugin/test.marko?dependencies");
 
       if (window.$mwp) {
         __webpack_require__.p = $mwp;
       }
 
-      __webpack_require__(/*! ./test.marko?dependencies */ "./src/__tests__/fixtures/with-class-component-plugin/test.marko?dependencies");
+      
       window.$initComponents && window.$initComponents();
     
 

--- a/src/__tests__/fixtures/with-css-extract/__snapshots__/main.js
+++ b/src/__tests__/fixtures/with-css-extract/__snapshots__/main.js
@@ -1,13 +1,52 @@
 /******/ ({
 
+/***/ "./node_modules/webpack/buildin/harmony-module.js":
+/*!*******************************************!*\
+  !*** (webpack)/buildin/harmony-module.js ***!
+  \*******************************************/
+/*! no static exports found */
+/***/ (function(module, exports) {
+
+module.exports = function(originalModule) {
+	if (!originalModule.webpackPolyfill) {
+		var module = Object.create(originalModule);
+		// module.parent = undefined by default
+		if (!module.children) module.children = [];
+		Object.defineProperty(module, "loaded", {
+			enumerable: true,
+			get: function() {
+				return module.l;
+			}
+		});
+		Object.defineProperty(module, "id", {
+			enumerable: true,
+			get: function() {
+				return module.i;
+			}
+		});
+		Object.defineProperty(module, "exports", {
+			enumerable: true
+		});
+		module.webpackPolyfill = 1;
+	}
+	return module;
+};
+
+
+/***/ }),
+
 /***/ "./src/__tests__/fixtures/with-css-extract/test.marko":
 /*!************************************************************!*\
   !*** ./src/__tests__/fixtures/with-css-extract/test.marko ***!
   \************************************************************/
-/*! no static exports found */
-/***/ (function(module, exports, __webpack_require__) {
+/*! no exports provided */
+/***/ (function(module, __webpack_exports__, __webpack_require__) {
 
-__webpack_require__(/*! ./test.marko.css */ "./src/__tests__/fixtures/with-css-extract/test.marko.css")
+"use strict";
+__webpack_require__.r(__webpack_exports__);
+/* WEBPACK VAR INJECTION */(function(module) {/* harmony import */ var _test_marko_css__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! ./test.marko.css */ "./src/__tests__/fixtures/with-css-extract/test.marko.css");
+/* harmony import */ var _test_marko_css__WEBPACK_IMPORTED_MODULE_0___default = /*#__PURE__*/__webpack_require__.n(_test_marko_css__WEBPACK_IMPORTED_MODULE_0__);
+
 "use strict";
 
 var marko_template = module.exports = __webpack_require__(/*! marko/dist/vdom */ "marko/dist/vdom").t(),
@@ -39,6 +78,7 @@ marko_template._ = marko_renderer(render, {
 
 marko_template.Component = marko_defineComponent({}, marko_template._);
 
+/* WEBPACK VAR INJECTION */}.call(this, __webpack_require__(/*! ./../../../../node_modules/webpack/buildin/harmony-module.js */ "./node_modules/webpack/buildin/harmony-module.js")(module)))
 
 /***/ }),
 

--- a/src/__tests__/fixtures/with-css/__snapshots__/main.js
+++ b/src/__tests__/fixtures/with-css/__snapshots__/main.js
@@ -403,14 +403,53 @@ module.exports = function (list, options) {
 
 /***/ }),
 
+/***/ "./node_modules/webpack/buildin/harmony-module.js":
+/*!*******************************************!*\
+  !*** (webpack)/buildin/harmony-module.js ***!
+  \*******************************************/
+/*! no static exports found */
+/***/ (function(module, exports) {
+
+module.exports = function(originalModule) {
+	if (!originalModule.webpackPolyfill) {
+		var module = Object.create(originalModule);
+		// module.parent = undefined by default
+		if (!module.children) module.children = [];
+		Object.defineProperty(module, "loaded", {
+			enumerable: true,
+			get: function() {
+				return module.l;
+			}
+		});
+		Object.defineProperty(module, "id", {
+			enumerable: true,
+			get: function() {
+				return module.i;
+			}
+		});
+		Object.defineProperty(module, "exports", {
+			enumerable: true
+		});
+		module.webpackPolyfill = 1;
+	}
+	return module;
+};
+
+
+/***/ }),
+
 /***/ "./src/__tests__/fixtures/with-css/test.marko":
 /*!****************************************************!*\
   !*** ./src/__tests__/fixtures/with-css/test.marko ***!
   \****************************************************/
-/*! no static exports found */
-/***/ (function(module, exports, __webpack_require__) {
+/*! no exports provided */
+/***/ (function(module, __webpack_exports__, __webpack_require__) {
 
-__webpack_require__(/*! ./test.marko.css */ "./src/__tests__/fixtures/with-css/test.marko.css")
+"use strict";
+__webpack_require__.r(__webpack_exports__);
+/* WEBPACK VAR INJECTION */(function(module) {/* harmony import */ var _test_marko_css__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! ./test.marko.css */ "./src/__tests__/fixtures/with-css/test.marko.css");
+/* harmony import */ var _test_marko_css__WEBPACK_IMPORTED_MODULE_0___default = /*#__PURE__*/__webpack_require__.n(_test_marko_css__WEBPACK_IMPORTED_MODULE_0__);
+
 "use strict";
 
 var marko_template = module.exports = __webpack_require__(/*! marko/dist/vdom */ "marko/dist/vdom").t(),
@@ -442,6 +481,7 @@ marko_template._ = marko_renderer(render, {
 
 marko_template.Component = marko_defineComponent({}, marko_template._);
 
+/* WEBPACK VAR INJECTION */}.call(this, __webpack_require__(/*! ./../../../../node_modules/webpack/buildin/harmony-module.js */ "./node_modules/webpack/buildin/harmony-module.js")(module)))
 
 /***/ }),
 

--- a/src/loader/index.ts
+++ b/src/loader/index.ts
@@ -103,9 +103,9 @@ export default function(source: string): string {
         __webpack_public_path__ = $mwp;
       }
 
-      require(${JSON.stringify(
+      import ${JSON.stringify(
         `./${path.basename(this.resourcePath)}?dependencies`
-      )});
+      )};
       window.$initComponents && window.$initComponents();
     `;
   } else if (target !== "server" && markoCompiler.compileForBrowser) {
@@ -128,10 +128,9 @@ export default function(source: string): string {
 
     if (dependenciesOnly && meta.component) {
       dependencies = dependencies.concat(`
-        require('marko/components').register(
-          ${JSON.stringify(meta.id)},
-          require(${JSON.stringify(meta.component)})
-        );
+      import { register } from "marko/components";
+      import component from ${JSON.stringify(meta.component)};
+      register(${JSON.stringify(meta.id)}, component);
       `);
     }
 
@@ -146,7 +145,7 @@ export default function(source: string): string {
               dependency = dependency.slice(browserJSONPrefix.length);
             }
             // external file, just require it
-            return `require(${JSON.stringify(dependency)});`;
+            return `import ${JSON.stringify(dependency)};`;
           } else {
             // inline content, we'll create a virtual dependency.
             const virtualPath = path.resolve(
@@ -155,7 +154,7 @@ export default function(source: string): string {
             );
             const virtualModules = getVirtualModules(this._compiler);
             virtualModules.writeModule(virtualPath, dependency.code);
-            return `require(${JSON.stringify(dependency.virtualPath)})`;
+            return `import ${JSON.stringify(dependency.virtualPath)};`;
           }
         })
       );
@@ -168,7 +167,7 @@ export default function(source: string): string {
         meta.tags
           .filter(tagPath => tagPath.endsWith(".marko"))
           .map(tagPath => {
-            return `require(${JSON.stringify(tagPath + "?dependencies")});`;
+            return `import ${JSON.stringify(tagPath + "?dependencies")};`;
           })
       );
     }


### PR DESCRIPTION
## Description
This PR updates the output from this plugin to always include additional dependencies as es modules instead of CommonJS requires. This improves support for components such as

```
export default class {
  onMount() {
    ...
  }
}
```

Which currently are not supported.

## Checklist:

- [ ] I have updated/added documentation affected by my changes.
- [x] I have added tests to cover my changes.
