### PR TITLE
feat: skip writing dynamic publicPath if publicPath is in output options

### DIFF
--- a/src/__tests__/fixtures/basic-template-plugin-custom-runtime-id/__snapshots__/browser--test_gpFj.js
+++ b/src/__tests__/fixtures/basic-template-plugin-custom-runtime-id/__snapshots__/browser--test_gpFj.js
@@ -19,10 +19,7 @@
 /***/ (function(module, exports, __webpack_require__) {
 
 
-      if (window.$mwp) {
-        __webpack_require__.p = $mwp;
-      }
-
+       if (window.$mwp) __webpack_require__.p = $mwp;
       __webpack_require__(/*! ./test.marko?dependencies */ "./src/__tests__/fixtures/basic-template-plugin-custom-runtime-id/test.marko?dependencies");
       
           const { init } = __webpack_require__(/*! marko/components */ "marko/components");

--- a/src/__tests__/fixtures/basic-template-plugin-custom-runtime-id/__snapshots__/server--main.js
+++ b/src/__tests__/fixtures/basic-template-plugin-custom-runtime-id/__snapshots__/server--main.js
@@ -96,7 +96,7 @@ function renderAssets() {
   this.end = this.___end;
 
   if (assets) {
-    this.script(`$mwp=${JSON.stringify(__webpack_require__.p)}`);
+    __webpack_require__.p && this.script(`$mwp=${JSON.stringify(__webpack_require__.p)}`);
 
     if (assets.js) {
       const setNonce = nonce && `.setAttribute("nonce", ${JSON.stringify(nonce)})`;

--- a/src/__tests__/fixtures/basic-template-plugin/__snapshots__/browser--test_uYWJ.js
+++ b/src/__tests__/fixtures/basic-template-plugin/__snapshots__/browser--test_uYWJ.js
@@ -19,10 +19,7 @@
 /***/ (function(module, exports, __webpack_require__) {
 
 
-      if (window.$mwp) {
-        __webpack_require__.p = $mwp;
-      }
-
+       if (window.$mwp) __webpack_require__.p = $mwp;
       __webpack_require__(/*! ./test.marko?dependencies */ "./src/__tests__/fixtures/basic-template-plugin/test.marko?dependencies");
       window.$initComponents && $initComponents();
       

--- a/src/__tests__/fixtures/basic-template-plugin/__snapshots__/server--main.js
+++ b/src/__tests__/fixtures/basic-template-plugin/__snapshots__/server--main.js
@@ -96,7 +96,7 @@ function renderAssets() {
   this.end = this.___end;
 
   if (assets) {
-    this.script(`$mwp=${JSON.stringify(__webpack_require__.p)}`);
+    __webpack_require__.p && this.script(`$mwp=${JSON.stringify(__webpack_require__.p)}`);
 
     if (assets.js) {
       const setNonce = nonce && `.setAttribute("nonce", ${JSON.stringify(nonce)})`;

--- a/src/__tests__/fixtures/multiple-entries-plugin/__snapshots__/browser--bar_aSxt.js
+++ b/src/__tests__/fixtures/multiple-entries-plugin/__snapshots__/browser--bar_aSxt.js
@@ -19,10 +19,7 @@ __webpack_require__(/*! ./components/shared.marko?dependencies */ "./src/__tests
 /***/ (function(module, exports, __webpack_require__) {
 
 
-      if (window.$mwp) {
-        __webpack_require__.p = $mwp;
-      }
-
+       if (window.$mwp) __webpack_require__.p = $mwp;
       __webpack_require__(/*! ./bar.marko?dependencies */ "./src/__tests__/fixtures/multiple-entries-plugin/bar.marko?dependencies");
       window.$initComponents && $initComponents();
       

--- a/src/__tests__/fixtures/multiple-entries-plugin/__snapshots__/browser--foo_3XPO.js
+++ b/src/__tests__/fixtures/multiple-entries-plugin/__snapshots__/browser--foo_3XPO.js
@@ -19,10 +19,7 @@ __webpack_require__(/*! ./components/shared.marko?dependencies */ "./src/__tests
 /***/ (function(module, exports, __webpack_require__) {
 
 
-      if (window.$mwp) {
-        __webpack_require__.p = $mwp;
-      }
-
+       if (window.$mwp) __webpack_require__.p = $mwp;
       __webpack_require__(/*! ./foo.marko?dependencies */ "./src/__tests__/fixtures/multiple-entries-plugin/foo.marko?dependencies");
       window.$initComponents && $initComponents();
       

--- a/src/__tests__/fixtures/multiple-entries-plugin/__snapshots__/server--main.js
+++ b/src/__tests__/fixtures/multiple-entries-plugin/__snapshots__/server--main.js
@@ -85,7 +85,7 @@ function renderAssets() {
   this.end = this.___end;
 
   if (assets) {
-    this.script(`$mwp=${JSON.stringify(__webpack_require__.p)}`);
+    __webpack_require__.p && this.script(`$mwp=${JSON.stringify(__webpack_require__.p)}`);
 
     if (assets.js) {
       const setNonce = nonce && `.setAttribute("nonce", ${JSON.stringify(nonce)})`;
@@ -257,7 +257,7 @@ function renderAssets() {
   this.end = this.___end;
 
   if (assets) {
-    this.script(`$mwp=${JSON.stringify(__webpack_require__.p)}`);
+    __webpack_require__.p && this.script(`$mwp=${JSON.stringify(__webpack_require__.p)}`);
 
     if (assets.js) {
       const setNonce = nonce && `.setAttribute("nonce", ${JSON.stringify(nonce)})`;

--- a/src/__tests__/fixtures/with-class-component-plugin-dynamic-bundle/__snapshots__/browser-A--test_YDNP.A.js
+++ b/src/__tests__/fixtures/with-class-component-plugin-dynamic-bundle/__snapshots__/browser-A--test_YDNP.A.js
@@ -103,10 +103,7 @@ __webpack_require__(/*! ./components/nested/index.marko?dependencies */ "./src/_
 /***/ (function(module, exports, __webpack_require__) {
 
 
-      if (window.$mwp) {
-        __webpack_require__.p = $mwp;
-      }
-
+       if (window.$mwp) __webpack_require__.p = $mwp;
       __webpack_require__(/*! ./test.marko?dependencies */ "./src/__tests__/fixtures/with-class-component-plugin-dynamic-bundle/test.marko?dependencies");
       window.$initComponents && $initComponents();
       

--- a/src/__tests__/fixtures/with-class-component-plugin-dynamic-bundle/__snapshots__/browser-B--test_YDNP.B.js
+++ b/src/__tests__/fixtures/with-class-component-plugin-dynamic-bundle/__snapshots__/browser-B--test_YDNP.B.js
@@ -103,10 +103,7 @@ __webpack_require__(/*! ./components/nested/index.marko?dependencies */ "./src/_
 /***/ (function(module, exports, __webpack_require__) {
 
 
-      if (window.$mwp) {
-        __webpack_require__.p = $mwp;
-      }
-
+       if (window.$mwp) __webpack_require__.p = $mwp;
       __webpack_require__(/*! ./test.marko?dependencies */ "./src/__tests__/fixtures/with-class-component-plugin-dynamic-bundle/test.marko?dependencies");
       window.$initComponents && $initComponents();
       

--- a/src/__tests__/fixtures/with-class-component-plugin-dynamic-bundle/__snapshots__/browser-C--test_YDNP.C.js
+++ b/src/__tests__/fixtures/with-class-component-plugin-dynamic-bundle/__snapshots__/browser-C--test_YDNP.C.js
@@ -103,10 +103,7 @@ __webpack_require__(/*! ./components/nested/index.marko?dependencies */ "./src/_
 /***/ (function(module, exports, __webpack_require__) {
 
 
-      if (window.$mwp) {
-        __webpack_require__.p = $mwp;
-      }
-
+       if (window.$mwp) __webpack_require__.p = $mwp;
       __webpack_require__(/*! ./test.marko?dependencies */ "./src/__tests__/fixtures/with-class-component-plugin-dynamic-bundle/test.marko?dependencies");
       window.$initComponents && $initComponents();
       

--- a/src/__tests__/fixtures/with-class-component-plugin-dynamic-bundle/__snapshots__/server--main.js
+++ b/src/__tests__/fixtures/with-class-component-plugin-dynamic-bundle/__snapshots__/server--main.js
@@ -158,7 +158,7 @@ function renderAssets() {
   this.end = this.___end;
 
   if (assets) {
-    this.script(`$mwp=${JSON.stringify(__webpack_require__.p)}`);
+    __webpack_require__.p && this.script(`$mwp=${JSON.stringify(__webpack_require__.p)}`);
 
     if (assets.js) {
       const setNonce = nonce && `.setAttribute("nonce", ${JSON.stringify(nonce)})`;

--- a/src/__tests__/fixtures/with-class-component-plugin/__snapshots__/browser--test_nzzJ.js
+++ b/src/__tests__/fixtures/with-class-component-plugin/__snapshots__/browser--test_nzzJ.js
@@ -101,10 +101,7 @@ __webpack_require__(/*! ./components/nested/index.marko?dependencies */ "./src/_
 /***/ (function(module, exports, __webpack_require__) {
 
 
-      if (window.$mwp) {
-        __webpack_require__.p = $mwp;
-      }
-
+       if (window.$mwp) __webpack_require__.p = $mwp;
       __webpack_require__(/*! ./test.marko?dependencies */ "./src/__tests__/fixtures/with-class-component-plugin/test.marko?dependencies");
       window.$initComponents && $initComponents();
       

--- a/src/__tests__/fixtures/with-public-path/__snapshots__/browser--test_CDVG.js
+++ b/src/__tests__/fixtures/with-public-path/__snapshots__/browser--test_CDVG.js
@@ -1,0 +1,30 @@
+/******/ ({
+
+/***/ "./src/__tests__/fixtures/with-public-path/test.marko?dependencies":
+/*!*************************************************************************!*\
+  !*** ./src/__tests__/fixtures/with-public-path/test.marko?dependencies ***!
+  \*************************************************************************/
+/*! no static exports found */
+/***/ (function(module, exports) {
+
+
+
+/***/ }),
+
+/***/ "./src/__tests__/fixtures/with-public-path/test.marko?hydrate":
+/*!********************************************************************!*\
+  !*** ./src/__tests__/fixtures/with-public-path/test.marko?hydrate ***!
+  \********************************************************************/
+/*! no static exports found */
+/***/ (function(module, exports, __webpack_require__) {
+
+
+      
+      __webpack_require__(/*! ./test.marko?dependencies */ "./src/__tests__/fixtures/with-public-path/test.marko?dependencies");
+      window.$initComponents && $initComponents();
+      
+    
+
+/***/ })
+
+/******/ });

--- a/src/__tests__/fixtures/with-public-path/__snapshots__/server--main.js
+++ b/src/__tests__/fixtures/with-public-path/__snapshots__/server--main.js
@@ -11,59 +11,20 @@ module.exports = {
   getAssets(entry) {
     return this.build[entry];
   },
-  build: {"test_nzzJ":{"css":["test_nzzJ.css"],"js":["test_nzzJ.js"]}}
+  build: {"test_CDVG":{"js":["test_CDVG.js"]}}
 }
 
 /***/ }),
 
-/***/ "./src/__tests__/fixtures/with-class-component-plugin/components/nested/index.marko":
-/*!******************************************************************************************!*\
-  !*** ./src/__tests__/fixtures/with-class-component-plugin/components/nested/index.marko ***!
-  \******************************************************************************************/
-/*! no static exports found */
-/***/ (function(module, exports, __webpack_require__) {
-
-"use strict";
-/* WEBPACK VAR INJECTION */(function(__filename) {
-
-var marko_template = module.exports = __webpack_require__(/*! marko/dist/html */ "marko/dist/html").t(__filename),
-    marko_component = {
-        onCreate: function() {}
-      },
-    marko_componentType = "/@marko/webpack-tests$x.x.x/fixtures/with-class-component-plugin/components/nested/index.marko",
-    marko_renderer = __webpack_require__(/*! marko/dist/runtime/components/renderer */ "marko/dist/runtime/components/renderer");
-
-function render(input, out, __component, component, state) {
-  var data = input;
-
-  out.w("<div></div>");
-}
-
-marko_template._ = marko_renderer(render, {
-    e_: marko_componentType
-  }, marko_component);
-
-marko_template.meta = {
-    deps: [
-      "./style.css"
-    ],
-    id: "/@marko/webpack-tests$x.x.x/fixtures/with-class-component-plugin/components/nested/index.marko",
-    component: "./index.marko"
-  };
-
-/* WEBPACK VAR INJECTION */}.call(this, "/index.js"))
-
-/***/ }),
-
-/***/ "./src/__tests__/fixtures/with-class-component-plugin/server.js":
-/*!**********************************************************************!*\
-  !*** ./src/__tests__/fixtures/with-class-component-plugin/server.js ***!
-  \**********************************************************************/
+/***/ "./src/__tests__/fixtures/with-public-path/server.js":
+/*!***********************************************************!*\
+  !*** ./src/__tests__/fixtures/with-public-path/server.js ***!
+  \***********************************************************/
 /*! no static exports found */
 /***/ (function(module, exports, __webpack_require__) {
 
 const http = __webpack_require__(/*! http */ "http");
-const test = __webpack_require__(/*! ./test.marko */ "./src/__tests__/fixtures/with-class-component-plugin/test.marko?assets");
+const test = __webpack_require__(/*! ./test.marko */ "./src/__tests__/fixtures/with-public-path/test.marko?assets");
 
 http
   .createServer((req, res) => {
@@ -74,10 +35,10 @@ http
 
 /***/ }),
 
-/***/ "./src/__tests__/fixtures/with-class-component-plugin/test.marko":
-/*!***********************************************************************!*\
-  !*** ./src/__tests__/fixtures/with-class-component-plugin/test.marko ***!
-  \***********************************************************************/
+/***/ "./src/__tests__/fixtures/with-public-path/test.marko":
+/*!************************************************************!*\
+  !*** ./src/__tests__/fixtures/with-public-path/test.marko ***!
+  \************************************************************/
 /*! no static exports found */
 /***/ (function(module, exports, __webpack_require__) {
 
@@ -85,18 +46,13 @@ http
 /* WEBPACK VAR INJECTION */(function(__filename) {
 
 var marko_template = module.exports = __webpack_require__(/*! marko/dist/html */ "marko/dist/html").t(__filename),
-    marko_componentType = "/@marko/webpack-tests$x.x.x/fixtures/with-class-component-plugin/test.marko",
-    marko_renderer = __webpack_require__(/*! marko/dist/runtime/components/renderer */ "marko/dist/runtime/components/renderer"),
-    nested_template = __webpack_require__(/*! ./components/nested/index.marko */ "./src/__tests__/fixtures/with-class-component-plugin/components/nested/index.marko"),
-    marko_loadTag = __webpack_require__(/*! marko/dist/runtime/helpers/load-tag */ "marko/dist/runtime/helpers/load-tag"),
-    nested_tag = marko_loadTag(nested_template);
+    marko_componentType = "/@marko/webpack-tests$x.x.x/fixtures/with-public-path/test.marko",
+    marko_renderer = __webpack_require__(/*! marko/dist/runtime/components/renderer */ "marko/dist/runtime/components/renderer");
 
 function render(input, out, __component, component, state) {
   var data = input;
 
   out.w("<h1>Hello World</h1>");
-
-  nested_tag({}, out, __component, "1");
 }
 
 marko_template._ = marko_renderer(render, {
@@ -105,28 +61,17 @@ marko_template._ = marko_renderer(render, {
   });
 
 marko_template.meta = {
-    deps: [
-      {
-          type: "css",
-          code: "h1 { color:red; }",
-          virtualPath: "./test.marko.css",
-          path: "./test.marko"
-        }
-    ],
-    id: "/@marko/webpack-tests$x.x.x/fixtures/with-class-component-plugin/test.marko",
-    tags: [
-      "./components/nested/index.marko"
-    ]
+    id: "/@marko/webpack-tests$x.x.x/fixtures/with-public-path/test.marko"
   };
 
 /* WEBPACK VAR INJECTION */}.call(this, "/index.js"))
 
 /***/ }),
 
-/***/ "./src/__tests__/fixtures/with-class-component-plugin/test.marko?assets":
-/*!******************************************************************************!*\
-  !*** ./src/__tests__/fixtures/with-class-component-plugin/test.marko?assets ***!
-  \******************************************************************************/
+/***/ "./src/__tests__/fixtures/with-public-path/test.marko?assets":
+/*!*******************************************************************!*\
+  !*** ./src/__tests__/fixtures/with-public-path/test.marko?assets ***!
+  \*******************************************************************/
 /*! no static exports found */
 /***/ (function(module, exports, __webpack_require__) {
 
@@ -134,9 +79,9 @@ marko_template.meta = {
 /* WEBPACK VAR INJECTION */(function(__filename) {
 
 var marko_template = module.exports = __webpack_require__(/*! marko/dist/html */ "marko/dist/html").t(__filename),
-    marko_componentType = "/@marko/webpack-tests$x.x.x/fixtures/with-class-component-plugin/test.marko",
+    marko_componentType = "/@marko/webpack-tests$x.x.x/fixtures/with-public-path/test.marko",
     marko_renderer = __webpack_require__(/*! marko/dist/runtime/components/renderer */ "marko/dist/runtime/components/renderer"),
-    template = __webpack_require__(/*! ./test.marko */ "./src/__tests__/fixtures/with-class-component-plugin/test.marko"),
+    template = __webpack_require__(/*! ./test.marko */ "./src/__tests__/fixtures/with-public-path/test.marko"),
     module_manifest = __webpack_require__(/*! ./../../../../__MARKO_WEBPACK__MANIFEST.js */ "./__MARKO_WEBPACK__MANIFEST.js"),
     manifest = module_manifest.default || module_manifest,
     marko_dynamicTag = __webpack_require__(/*! marko/dist/runtime/helpers/dynamic-tag */ "marko/dist/runtime/helpers/dynamic-tag"),
@@ -151,7 +96,7 @@ function renderAssets() {
   this.end = this.___end;
 
   if (assets) {
-    __webpack_require__.p && this.script(`$mwp=${JSON.stringify(__webpack_require__.p)}`);
+    
 
     if (assets.js) {
       const setNonce = nonce && `.setAttribute("nonce", ${JSON.stringify(nonce)})`;
@@ -191,7 +136,7 @@ function render(input, out, __component, component, state) {
 
   out.___renderAssets = renderAssets;
 
-  out.___assets = manifest.getAssets("test_nzzJ", out.global.buildName);
+  out.___assets = manifest.getAssets("test_CDVG", out.global.buildName);
 
   out.flush = outFlushOverride;
 
@@ -210,7 +155,7 @@ marko_template._ = marko_renderer(render, {
   });
 
 marko_template.meta = {
-    id: "/@marko/webpack-tests$x.x.x/fixtures/with-class-component-plugin/test.marko",
+    id: "/@marko/webpack-tests$x.x.x/fixtures/with-public-path/test.marko",
     tags: [
       "./test.marko",
       "marko/dist/core-tags/components/init-components-tag"

--- a/src/__tests__/fixtures/with-public-path/server.js
+++ b/src/__tests__/fixtures/with-public-path/server.js
@@ -1,0 +1,8 @@
+const http = require("http");
+const test = require("./test.marko");
+
+http
+  .createServer((req, res) => {
+    test.render({}, res);
+  })
+  .listen(0);

--- a/src/__tests__/fixtures/with-public-path/test.marko
+++ b/src/__tests__/fixtures/with-public-path/test.marko
@@ -1,0 +1,1 @@
+<h1>Hello World</h1>

--- a/src/__tests__/fixtures/with-public-path/webpack.config.ts
+++ b/src/__tests__/fixtures/with-public-path/webpack.config.ts
@@ -1,0 +1,43 @@
+import * as path from "path";
+import * as webpack from "webpack";
+import MarkoPlugin from "../../../plugin";
+
+const markoPlugin = new MarkoPlugin();
+const publicPath = "/assets";
+
+export default [
+  {
+    name: "server",
+    target: "async-node",
+    entry: path.join(__dirname, "server.js"),
+    output: { publicPath },
+    module: {
+      rules: [
+        {
+          test: /\.marko$/,
+          loader: "@marko/webpack/loader"
+        }
+      ]
+    },
+    plugins: [
+      new webpack.DefinePlugin({
+        "process.env.BUNDLE": true
+      }),
+      markoPlugin.server
+    ]
+  },
+  {
+    name: "browser",
+    target: "web",
+    output: { publicPath },
+    module: {
+      rules: [
+        {
+          test: /\.marko$/,
+          loader: "@marko/webpack/loader"
+        }
+      ]
+    },
+    plugins: [markoPlugin.browser]
+  }
+];

--- a/src/loader/get-asset-code.ts
+++ b/src/loader/get-asset-code.ts
@@ -2,7 +2,11 @@ import * as path from "path";
 import moduleName from "../shared/module-name";
 import { VIRTUAL_SERVER_MANIFEST_PATH } from "../shared/virtual";
 
-export default (resourcePath: string, runtimeId: string | undefined): string => `
+export default (
+  resourcePath: string,
+  runtimeId: string | undefined,
+  publicPath: string | undefined
+): string => `
 import template from ${JSON.stringify(`./${path.basename(resourcePath)}`)};
 import manifest from ${JSON.stringify(
   `./${path.relative(path.dirname(resourcePath), VIRTUAL_SERVER_MANIFEST_PATH)}`
@@ -16,7 +20,11 @@ static function renderAssets() {
   this.end = this.___end;
 
   if (assets) {
-    this.script(\`$mwp=\${JSON.stringify(__webpack_public_path__)}\`);
+    ${
+      publicPath === undefined
+        ? "__webpack_public_path__ && this.script(`$mwp=${JSON.stringify(__webpack_public_path__)}`);"
+        : ""
+    }
 
     if (assets.js) {
       const setNonce = nonce && \`.setAttribute("nonce", \${JSON.stringify(nonce)})\`;
@@ -47,7 +55,7 @@ static function outEndOverride(data, encoding, callback) {
   this.end(data, encoding, callback);
 }
 
-${runtimeId === undefined ? "" : `$ out.global.runtimeId = ${runtimeId};` }
+${runtimeId === undefined ? "" : `$ out.global.runtimeId = ${runtimeId};`}
 $ out.___flush = out.flush;
 $ out.___end = out.end;
 $ out.___renderAssets = renderAssets;


### PR DESCRIPTION
## Description

This plugin [automatically syncs the __webpack_public_path__](https://github.com/marko-js/webpack#dynamic-public-paths) from the server side compilation to the browser side using a global window variable in an injected script.

This code is no longer output if a static [`publicPath`](https://webpack.js.org/configuration/output/#outputpublicpath) option is configured for both the server side and client side compiler in your webpack config.

## Checklist:

- [ ] I have updated/added documentation affected by my changes.
- [x] I have added tests to cover my changes.
