### PR TITLE
fix: include runtimeId in dynamic public path var

### DIFF
--- a/src/__tests__/fixtures/basic-template-plugin-custom-runtime-id/__snapshots__/browser--test_gpFj.js
+++ b/src/__tests__/fixtures/basic-template-plugin-custom-runtime-id/__snapshots__/browser--test_gpFj.js
@@ -19,7 +19,7 @@
 /***/ (function(module, exports, __webpack_require__) {
 
 
-       if (window.$mwp) __webpack_require__.p = $mwp;
+       if (window.$mwp_testruntime) __webpack_require__.p = $mwp_testruntime;
       __webpack_require__(/*! ./test.marko?dependencies */ "./src/__tests__/fixtures/basic-template-plugin-custom-runtime-id/test.marko?dependencies");
       
           const { init } = __webpack_require__(/*! marko/components */ "marko/components");

--- a/src/__tests__/fixtures/basic-template-plugin-custom-runtime-id/__snapshots__/server--main.js
+++ b/src/__tests__/fixtures/basic-template-plugin-custom-runtime-id/__snapshots__/server--main.js
@@ -96,7 +96,7 @@ function renderAssets() {
   this.end = this.___end;
 
   if (assets) {
-    __webpack_require__.p && this.script(`$mwp=${JSON.stringify(__webpack_require__.p)}`);
+    __webpack_require__.p && this.script(`$mwp_testruntime=${JSON.stringify(__webpack_require__.p)}`);
 
     if (assets.js) {
       const setNonce = nonce && `.setAttribute("nonce", ${JSON.stringify(nonce)})`;

--- a/src/loader/get-asset-code.ts
+++ b/src/loader/get-asset-code.ts
@@ -22,7 +22,9 @@ static function renderAssets() {
   if (assets) {
     ${
       publicPath === undefined
-        ? "__webpack_public_path__ && this.script(`$mwp=${JSON.stringify(__webpack_public_path__)}`);"
+        ? `__webpack_public_path__ && this.script(\`${
+            runtimeId ? `$mwp_${runtimeId}` : "$mwp"
+          }=\${JSON.stringify(__webpack_public_path__)}\`);`
         : ""
     }
 
@@ -55,7 +57,11 @@ static function outEndOverride(data, encoding, callback) {
   this.end(data, encoding, callback);
 }
 
-${runtimeId === undefined ? "" : `$ out.global.runtimeId = ${runtimeId};`}
+${
+  runtimeId === undefined
+    ? ""
+    : `$ out.global.runtimeId = ${JSON.stringify(runtimeId)};`
+}
 $ out.___flush = out.flush;
 $ out.___end = out.end;
 $ out.___renderAssets = renderAssets;

--- a/src/loader/index.ts
+++ b/src/loader/index.ts
@@ -124,10 +124,15 @@ export default function(source: string): string {
       }
     );
   } else if (hydrate) {
+    let mwpVar = "$mwp";
+    if (runtimeId) {
+      mwpVar += `_${runtimeId}`;
+    }
+
     return `
       ${
         publicPath === undefined
-          ? " if (window.$mwp) __webpack_public_path__ = $mwp;"
+          ? ` if (window.${mwpVar}) __webpack_public_path__ = ${mwpVar};`
           : ""
       }
       ${loadStr(`./${path.basename(this.resourcePath)}?dependencies`)}
@@ -135,7 +140,7 @@ export default function(source: string): string {
         runtimeId
           ? `
           ${loadStr("marko/components", "{ init }")}
-          init(${runtimeId});
+          init(${JSON.stringify(runtimeId)});
         `
           : "window.$initComponents && $initComponents();"
       }

--- a/src/plugin/index.ts
+++ b/src/plugin/index.ts
@@ -35,10 +35,7 @@ export default class MarkoWebpackPlugin {
   });
 
   constructor(private options?: { runtimeId?: string }) {
-    this.options = { ...options };
-    if (this.options.runtimeId) {
-      this.options.runtimeId = JSON.stringify(options.runtimeId);
-    }
+    this.options = options;
   }
 
   // Overwritten by each compiler.


### PR DESCRIPTION
## Description

When the `runtimeId` options is used, the `$mwp` global (used to sync the `__webpack_public_path__` from the server) will now be properly prefixed with that id similar to other globals added by the Marko runtime, eg `$mwp_MY_RUNTIME_ID`.
## Screenshots (if appropriate):

## Checklist:

- [ ] I have updated/added documentation affected by my changes.
- [x] I have added tests to cover my changes.
