### PR TITLE
feat: load scripts via async script tag

### DIFF
--- a/src/__tests__/fixtures/basic-template-plugin-custom-runtime-id/__snapshots__/server--main.js
+++ b/src/__tests__/fixtures/basic-template-plugin-custom-runtime-id/__snapshots__/server--main.js
@@ -99,12 +99,12 @@ function renderAssets() {
     __webpack_require__.p && this.script(`$mwp_testruntime=${JSON.stringify(__webpack_require__.p)}`);
 
     if (assets.js) {
-      const setNonce = nonce && `.setAttribute("nonce", ${JSON.stringify(nonce)})`;
-      this.script(
-        `(function(b,h){var e=[],c=0;h.forEach(function(d,f){var a=b.createElement("link");a.relList&&a.relList.supports&&a.relList.supports("preload")?(a.href=d,a.rel="preload",a.as="script",a.addEventListener("load",function(){e[f]=d;if(c===f)for(var a;a=e[c];c++){var g=b.createElement("script");g.src=a;${setNonce ? `g${setNonce};` : ""}b.head.appendChild(g)}}),b.head.appendChild(a)):(a=b.createElement("script"),a.src=d,a.defer=!0,${setNonce ? `a${setNonce},` : ""}b.head.appendChild(a))})})(document,${
-          JSON.stringify(assets.js.map(js => __webpack_require__.p+js))
-        })`
-      );
+      const nonceAttr = nonce ? ` nonce=${JSON.stringify(nonce)}` : "";
+      assets.js.forEach(js => {
+        this.write(
+          `<script src=${JSON.stringify(__webpack_require__.p+js)}${nonceAttr} async></script>`
+        );
+      });
     }
 
     if (assets.css) {

--- a/src/__tests__/fixtures/basic-template-plugin/__snapshots__/server--main.js
+++ b/src/__tests__/fixtures/basic-template-plugin/__snapshots__/server--main.js
@@ -99,12 +99,12 @@ function renderAssets() {
     __webpack_require__.p && this.script(`$mwp=${JSON.stringify(__webpack_require__.p)}`);
 
     if (assets.js) {
-      const setNonce = nonce && `.setAttribute("nonce", ${JSON.stringify(nonce)})`;
-      this.script(
-        `(function(b,h){var e=[],c=0;h.forEach(function(d,f){var a=b.createElement("link");a.relList&&a.relList.supports&&a.relList.supports("preload")?(a.href=d,a.rel="preload",a.as="script",a.addEventListener("load",function(){e[f]=d;if(c===f)for(var a;a=e[c];c++){var g=b.createElement("script");g.src=a;${setNonce ? `g${setNonce};` : ""}b.head.appendChild(g)}}),b.head.appendChild(a)):(a=b.createElement("script"),a.src=d,a.defer=!0,${setNonce ? `a${setNonce},` : ""}b.head.appendChild(a))})})(document,${
-          JSON.stringify(assets.js.map(js => __webpack_require__.p+js))
-        })`
-      );
+      const nonceAttr = nonce ? ` nonce=${JSON.stringify(nonce)}` : "";
+      assets.js.forEach(js => {
+        this.write(
+          `<script src=${JSON.stringify(__webpack_require__.p+js)}${nonceAttr} async></script>`
+        );
+      });
     }
 
     if (assets.css) {

--- a/src/__tests__/fixtures/multiple-entries-plugin/__snapshots__/server--main.js
+++ b/src/__tests__/fixtures/multiple-entries-plugin/__snapshots__/server--main.js
@@ -88,12 +88,12 @@ function renderAssets() {
     __webpack_require__.p && this.script(`$mwp=${JSON.stringify(__webpack_require__.p)}`);
 
     if (assets.js) {
-      const setNonce = nonce && `.setAttribute("nonce", ${JSON.stringify(nonce)})`;
-      this.script(
-        `(function(b,h){var e=[],c=0;h.forEach(function(d,f){var a=b.createElement("link");a.relList&&a.relList.supports&&a.relList.supports("preload")?(a.href=d,a.rel="preload",a.as="script",a.addEventListener("load",function(){e[f]=d;if(c===f)for(var a;a=e[c];c++){var g=b.createElement("script");g.src=a;${setNonce ? `g${setNonce};` : ""}b.head.appendChild(g)}}),b.head.appendChild(a)):(a=b.createElement("script"),a.src=d,a.defer=!0,${setNonce ? `a${setNonce},` : ""}b.head.appendChild(a))})})(document,${
-          JSON.stringify(assets.js.map(js => __webpack_require__.p+js))
-        })`
-      );
+      const nonceAttr = nonce ? ` nonce=${JSON.stringify(nonce)}` : "";
+      assets.js.forEach(js => {
+        this.write(
+          `<script src=${JSON.stringify(__webpack_require__.p+js)}${nonceAttr} async></script>`
+        );
+      });
     }
 
     if (assets.css) {
@@ -260,12 +260,12 @@ function renderAssets() {
     __webpack_require__.p && this.script(`$mwp=${JSON.stringify(__webpack_require__.p)}`);
 
     if (assets.js) {
-      const setNonce = nonce && `.setAttribute("nonce", ${JSON.stringify(nonce)})`;
-      this.script(
-        `(function(b,h){var e=[],c=0;h.forEach(function(d,f){var a=b.createElement("link");a.relList&&a.relList.supports&&a.relList.supports("preload")?(a.href=d,a.rel="preload",a.as="script",a.addEventListener("load",function(){e[f]=d;if(c===f)for(var a;a=e[c];c++){var g=b.createElement("script");g.src=a;${setNonce ? `g${setNonce};` : ""}b.head.appendChild(g)}}),b.head.appendChild(a)):(a=b.createElement("script"),a.src=d,a.defer=!0,${setNonce ? `a${setNonce},` : ""}b.head.appendChild(a))})})(document,${
-          JSON.stringify(assets.js.map(js => __webpack_require__.p+js))
-        })`
-      );
+      const nonceAttr = nonce ? ` nonce=${JSON.stringify(nonce)}` : "";
+      assets.js.forEach(js => {
+        this.write(
+          `<script src=${JSON.stringify(__webpack_require__.p+js)}${nonceAttr} async></script>`
+        );
+      });
     }
 
     if (assets.css) {

--- a/src/__tests__/fixtures/with-class-component-plugin-dynamic-bundle/__snapshots__/server--main.js
+++ b/src/__tests__/fixtures/with-class-component-plugin-dynamic-bundle/__snapshots__/server--main.js
@@ -161,12 +161,12 @@ function renderAssets() {
     __webpack_require__.p && this.script(`$mwp=${JSON.stringify(__webpack_require__.p)}`);
 
     if (assets.js) {
-      const setNonce = nonce && `.setAttribute("nonce", ${JSON.stringify(nonce)})`;
-      this.script(
-        `(function(b,h){var e=[],c=0;h.forEach(function(d,f){var a=b.createElement("link");a.relList&&a.relList.supports&&a.relList.supports("preload")?(a.href=d,a.rel="preload",a.as="script",a.addEventListener("load",function(){e[f]=d;if(c===f)for(var a;a=e[c];c++){var g=b.createElement("script");g.src=a;${setNonce ? `g${setNonce};` : ""}b.head.appendChild(g)}}),b.head.appendChild(a)):(a=b.createElement("script"),a.src=d,a.defer=!0,${setNonce ? `a${setNonce},` : ""}b.head.appendChild(a))})})(document,${
-          JSON.stringify(assets.js.map(js => __webpack_require__.p+js))
-        })`
-      );
+      const nonceAttr = nonce ? ` nonce=${JSON.stringify(nonce)}` : "";
+      assets.js.forEach(js => {
+        this.write(
+          `<script src=${JSON.stringify(__webpack_require__.p+js)}${nonceAttr} async></script>`
+        );
+      });
     }
 
     if (assets.css) {

--- a/src/__tests__/fixtures/with-class-component-plugin/__snapshots__/server--main.js
+++ b/src/__tests__/fixtures/with-class-component-plugin/__snapshots__/server--main.js
@@ -154,12 +154,12 @@ function renderAssets() {
     __webpack_require__.p && this.script(`$mwp=${JSON.stringify(__webpack_require__.p)}`);
 
     if (assets.js) {
-      const setNonce = nonce && `.setAttribute("nonce", ${JSON.stringify(nonce)})`;
-      this.script(
-        `(function(b,h){var e=[],c=0;h.forEach(function(d,f){var a=b.createElement("link");a.relList&&a.relList.supports&&a.relList.supports("preload")?(a.href=d,a.rel="preload",a.as="script",a.addEventListener("load",function(){e[f]=d;if(c===f)for(var a;a=e[c];c++){var g=b.createElement("script");g.src=a;${setNonce ? `g${setNonce};` : ""}b.head.appendChild(g)}}),b.head.appendChild(a)):(a=b.createElement("script"),a.src=d,a.defer=!0,${setNonce ? `a${setNonce},` : ""}b.head.appendChild(a))})})(document,${
-          JSON.stringify(assets.js.map(js => __webpack_require__.p+js))
-        })`
-      );
+      const nonceAttr = nonce ? ` nonce=${JSON.stringify(nonce)}` : "";
+      assets.js.forEach(js => {
+        this.write(
+          `<script src=${JSON.stringify(__webpack_require__.p+js)}${nonceAttr} async></script>`
+        );
+      });
     }
 
     if (assets.css) {

--- a/src/__tests__/fixtures/with-public-path/__snapshots__/server--main.js
+++ b/src/__tests__/fixtures/with-public-path/__snapshots__/server--main.js
@@ -99,12 +99,12 @@ function renderAssets() {
     
 
     if (assets.js) {
-      const setNonce = nonce && `.setAttribute("nonce", ${JSON.stringify(nonce)})`;
-      this.script(
-        `(function(b,h){var e=[],c=0;h.forEach(function(d,f){var a=b.createElement("link");a.relList&&a.relList.supports&&a.relList.supports("preload")?(a.href=d,a.rel="preload",a.as="script",a.addEventListener("load",function(){e[f]=d;if(c===f)for(var a;a=e[c];c++){var g=b.createElement("script");g.src=a;${setNonce ? `g${setNonce};` : ""}b.head.appendChild(g)}}),b.head.appendChild(a)):(a=b.createElement("script"),a.src=d,a.defer=!0,${setNonce ? `a${setNonce},` : ""}b.head.appendChild(a))})})(document,${
-          JSON.stringify(assets.js.map(js => __webpack_require__.p+js))
-        })`
-      );
+      const nonceAttr = nonce ? ` nonce=${JSON.stringify(nonce)}` : "";
+      assets.js.forEach(js => {
+        this.write(
+          `<script src=${JSON.stringify(__webpack_require__.p+js)}${nonceAttr} async></script>`
+        );
+      });
     }
 
     if (assets.css) {

--- a/src/loader/get-asset-code.ts
+++ b/src/loader/get-asset-code.ts
@@ -29,12 +29,12 @@ static function renderAssets() {
     }
 
     if (assets.js) {
-      const setNonce = nonce && \`.setAttribute("nonce", \${JSON.stringify(nonce)})\`;
-      this.script(
-        \`(function(b,h){var e=[],c=0;h.forEach(function(d,f){var a=b.createElement("link");a.relList&&a.relList.supports&&a.relList.supports("preload")?(a.href=d,a.rel="preload",a.as="script",a.addEventListener("load",function(){e[f]=d;if(c===f)for(var a;a=e[c];c++){var g=b.createElement("script");g.src=a;\${setNonce ? \`g\${setNonce};\` : ""}b.head.appendChild(g)}}),b.head.appendChild(a)):(a=b.createElement("script"),a.src=d,a.defer=!0,\${setNonce ? \`a\${setNonce},\` : ""}b.head.appendChild(a))})})(document,\${
-          JSON.stringify(assets.js.map(js => __webpack_public_path__+js))
-        })\`
-      );
+      const nonceAttr = nonce ? \` nonce=\${JSON.stringify(nonce)}\` : "";
+      assets.js.forEach(js => {
+        this.write(
+          \`<script src=\${JSON.stringify(__webpack_public_path__+js)}\${nonceAttr} async></script>\`
+        );
+      });
     }
 
     if (assets.css) {


### PR DESCRIPTION
## Description

This PR removes the asset loading strategy which previously inlined preload links and orchestrated script execution order.

It turns out this was unnecessary since the webpack runtime actually orchestrates script execution properly even when assets are loaded in the incorrect order. This means we are able to switch to a much simpler and better supported solution of using `<script async>`. 🎉 

## Checklist:

- [ ] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.
