### PR TITLE
fix: automatically configure webpack options when runtimeid set

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,6 +202,8 @@ const markoPlugin = new MarkoPlugin({
 });
 ```
 
+Note: This option will also override the default values for the `jsonpFunction`, `chunkCallbackName` and `hotUpdateFunction` webpack `output` options, which all use global variables, to be prefixed with the `runtimeId`.
+
 ## Dynamic public paths
 
 When using the plugin, the server will automatically sync the runtime [`__webpack_public_path__`](https://webpack.js.org/guides/public-path/#on-the-fly) with the browser.


### PR DESCRIPTION
## Description

This PR updates the `runtimeId` plugin option to override the default values for webpack `output` options which use global variables to prefix them with the `runtimeId`.

## Checklist:

- [x] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.
