### PR TITLE
fix: optimize component registration for top level stateful components

### DIFF
--- a/src/__tests__/fixtures/with-class-component-plugin-dynamic-bundle/__snapshots__/browser-A--test_YDNP.A.js
+++ b/src/__tests__/fixtures/with-class-component-plugin-dynamic-bundle/__snapshots__/browser-A--test_YDNP.A.js
@@ -52,11 +52,7 @@ marko_template.Component = marko_defineComponent(marko_component, marko_template
 /*! no static exports found */
 /***/ (function(module, exports, __webpack_require__) {
 
-
-      const { register } = __webpack_require__(/*! marko/components */ "marko/components");
-      const component = __webpack_require__(/*! ./index.marko */ "./src/__tests__/fixtures/with-class-component-plugin-dynamic-bundle/components/nested/index.marko");
-      register("/@marko/webpack-tests$x.x.x/fixtures/with-class-component-plugin-dynamic-bundle/components/nested/index.marko", component);
-      
+__webpack_require__(/*! ./index.marko */ "./src/__tests__/fixtures/with-class-component-plugin-dynamic-bundle/components/nested/index.marko");
 __webpack_require__(/*! ./style.css */ "./src/__tests__/fixtures/with-class-component-plugin-dynamic-bundle/components/nested/style.css");
 
 /***/ }),
@@ -108,17 +104,6 @@ __webpack_require__(/*! ./components/nested/index.marko?dependencies */ "./src/_
       window.$initComponents && $initComponents();
       
     
-
-/***/ }),
-
-/***/ "marko/components":
-/*!***********************************!*\
-  !*** external "marko/components" ***!
-  \***********************************/
-/*! no static exports found */
-/***/ (function(module, exports) {
-
-module.exports = marko/components;
 
 /***/ }),
 

--- a/src/__tests__/fixtures/with-class-component-plugin-dynamic-bundle/__snapshots__/browser-B--test_YDNP.B.js
+++ b/src/__tests__/fixtures/with-class-component-plugin-dynamic-bundle/__snapshots__/browser-B--test_YDNP.B.js
@@ -52,11 +52,7 @@ marko_template.Component = marko_defineComponent(marko_component, marko_template
 /*! no static exports found */
 /***/ (function(module, exports, __webpack_require__) {
 
-
-      const { register } = __webpack_require__(/*! marko/components */ "marko/components");
-      const component = __webpack_require__(/*! ./index.marko */ "./src/__tests__/fixtures/with-class-component-plugin-dynamic-bundle/components/nested/index.marko");
-      register("/@marko/webpack-tests$x.x.x/fixtures/with-class-component-plugin-dynamic-bundle/components/nested/index.marko", component);
-      
+__webpack_require__(/*! ./index.marko */ "./src/__tests__/fixtures/with-class-component-plugin-dynamic-bundle/components/nested/index.marko");
 __webpack_require__(/*! ./style.css */ "./src/__tests__/fixtures/with-class-component-plugin-dynamic-bundle/components/nested/style.css");
 
 /***/ }),
@@ -108,17 +104,6 @@ __webpack_require__(/*! ./components/nested/index.marko?dependencies */ "./src/_
       window.$initComponents && $initComponents();
       
     
-
-/***/ }),
-
-/***/ "marko/components":
-/*!***********************************!*\
-  !*** external "marko/components" ***!
-  \***********************************/
-/*! no static exports found */
-/***/ (function(module, exports) {
-
-module.exports = marko/components;
 
 /***/ }),
 

--- a/src/__tests__/fixtures/with-class-component-plugin-dynamic-bundle/__snapshots__/browser-C--test_YDNP.C.js
+++ b/src/__tests__/fixtures/with-class-component-plugin-dynamic-bundle/__snapshots__/browser-C--test_YDNP.C.js
@@ -52,11 +52,7 @@ marko_template.Component = marko_defineComponent(marko_component, marko_template
 /*! no static exports found */
 /***/ (function(module, exports, __webpack_require__) {
 
-
-      const { register } = __webpack_require__(/*! marko/components */ "marko/components");
-      const component = __webpack_require__(/*! ./index.marko */ "./src/__tests__/fixtures/with-class-component-plugin-dynamic-bundle/components/nested/index.marko");
-      register("/@marko/webpack-tests$x.x.x/fixtures/with-class-component-plugin-dynamic-bundle/components/nested/index.marko", component);
-      
+__webpack_require__(/*! ./index.marko */ "./src/__tests__/fixtures/with-class-component-plugin-dynamic-bundle/components/nested/index.marko");
 __webpack_require__(/*! ./style.css */ "./src/__tests__/fixtures/with-class-component-plugin-dynamic-bundle/components/nested/style.css");
 
 /***/ }),
@@ -108,17 +104,6 @@ __webpack_require__(/*! ./components/nested/index.marko?dependencies */ "./src/_
       window.$initComponents && $initComponents();
       
     
-
-/***/ }),
-
-/***/ "marko/components":
-/*!***********************************!*\
-  !*** external "marko/components" ***!
-  \***********************************/
-/*! no static exports found */
-/***/ (function(module, exports) {
-
-module.exports = marko/components;
 
 /***/ }),
 

--- a/src/__tests__/fixtures/with-class-component-plugin/__snapshots__/browser--test_nzzJ.js
+++ b/src/__tests__/fixtures/with-class-component-plugin/__snapshots__/browser--test_nzzJ.js
@@ -50,11 +50,7 @@ marko_template.Component = marko_defineComponent(marko_component, marko_template
 /*! no static exports found */
 /***/ (function(module, exports, __webpack_require__) {
 
-
-      const { register } = __webpack_require__(/*! marko/components */ "marko/components");
-      const component = __webpack_require__(/*! ./index.marko */ "./src/__tests__/fixtures/with-class-component-plugin/components/nested/index.marko");
-      register("/@marko/webpack-tests$x.x.x/fixtures/with-class-component-plugin/components/nested/index.marko", component);
-      
+__webpack_require__(/*! ./index.marko */ "./src/__tests__/fixtures/with-class-component-plugin/components/nested/index.marko");
 __webpack_require__(/*! ./style.css */ "./src/__tests__/fixtures/with-class-component-plugin/components/nested/style.css");
 
 /***/ }),
@@ -106,17 +102,6 @@ __webpack_require__(/*! ./components/nested/index.marko?dependencies */ "./src/_
       window.$initComponents && $initComponents();
       
     
-
-/***/ }),
-
-/***/ "marko/components":
-/*!***********************************!*\
-  !*** external "marko/components" ***!
-  \***********************************/
-/*! no static exports found */
-/***/ (function(module, exports) {
-
-module.exports = marko/components;
 
 /***/ }),
 

--- a/src/loader/index.ts
+++ b/src/loader/index.ts
@@ -92,7 +92,6 @@ export default function(source: string): string {
     babelConfig.caller
   );
 
-  const dependenciesOnly = this.resource.endsWith("?dependencies");
   const hydrate = this.resource.endsWith("?hydrate");
   const assets = this.resource.endsWith("?assets");
   let sourceMaps =
@@ -163,14 +162,22 @@ export default function(source: string): string {
       this.addDependency(dep)
     );
 
+    const dependenciesOnly = this.resource.endsWith("?dependencies");
     let dependencies = [];
 
     if (dependenciesOnly && meta.component) {
-      dependencies = dependencies.concat(`
-      ${loadStr("marko/components", "{ register }")}
-      ${loadStr(meta.component, "component")}
-      register(${JSON.stringify(meta.id)}, component);
-      `);
+      if (
+        path.join(path.dirname(this.resourcePath), meta.component) ===
+        this.resourcePath
+      ) {
+        dependencies.push(loadStr(meta.component));
+      } else {
+        dependencies = dependencies.concat(`
+        ${loadStr("marko/components", "{ register }")}
+        ${loadStr(meta.component, "component")}
+        register(${JSON.stringify(meta.id)}, component);
+        `);
+      }
     }
 
     if (meta.deps) {


### PR DESCRIPTION
## Description

Currently when we are in `dependenciesOnly` mode in the plugin, we require all dependencies for a component, and register the component `class` if it exists. This means for top stateful components we actually register the component twice since stateful components already include code to register themselves. This optimizes this by checking to see if the dependency for the component that we are adding is itself, and skips the registration.

## Checklist:

- [ ] I have updated/added documentation affected by my changes.
- [x] I have added tests to cover my changes.
