### PR TITLE
fix: include component-globals and await-reorderer tags inn ssr code

### DIFF
--- a/src/__tests__/fixtures/basic-template-plugin-custom-runtime-id/__snapshots__/server--main.js
+++ b/src/__tests__/fixtures/basic-template-plugin-custom-runtime-id/__snapshots__/server--main.js
@@ -84,9 +84,11 @@ var marko_template = module.exports = __webpack_require__(/*! marko/dist/html */
     template = __webpack_require__(/*! ./test.marko */ "./src/__tests__/fixtures/basic-template-plugin-custom-runtime-id/test.marko"),
     module_manifest = __webpack_require__(/*! ./../../../../__MARKO_WEBPACK__MANIFEST.js */ "./__MARKO_WEBPACK__MANIFEST.js"),
     manifest = module_manifest.default || module_manifest,
-    marko_dynamicTag = __webpack_require__(/*! marko/dist/runtime/helpers/dynamic-tag */ "marko/dist/runtime/helpers/dynamic-tag"),
     marko_loadTag = __webpack_require__(/*! marko/dist/runtime/helpers/load-tag */ "marko/dist/runtime/helpers/load-tag"),
-    init_components_tag = marko_loadTag(__webpack_require__(/*! marko/dist/core-tags/components/init-components-tag */ "marko/dist/core-tags/components/init-components-tag"));
+    component_globals_tag = marko_loadTag(__webpack_require__(/*! marko/dist/core-tags/components/component-globals-tag */ "marko/dist/core-tags/components/component-globals-tag")),
+    marko_dynamicTag = __webpack_require__(/*! marko/dist/runtime/helpers/dynamic-tag */ "marko/dist/runtime/helpers/dynamic-tag"),
+    init_components_tag = marko_loadTag(__webpack_require__(/*! marko/dist/core-tags/components/init-components-tag */ "marko/dist/core-tags/components/init-components-tag")),
+    await_reorderer_tag = marko_loadTag(__webpack_require__(/*! marko/dist/core-tags/core/await/reorderer-renderer */ "marko/dist/core-tags/core/await/reorderer-renderer"));
 
 function renderAssets() {
   const assets = this.___assets;
@@ -144,11 +146,15 @@ function render(input, out, __component, component, state) {
 
   out.end = outEndOverride;
 
+  component_globals_tag({}, out);
+
   marko_dynamicTag(out, template, function() {
     return input;
   }, null, null, null, __component, "0");
 
   init_components_tag({}, out);
+
+  await_reorderer_tag({}, out, __component, "1");
 }
 
 marko_template._ = marko_renderer(render, {
@@ -160,7 +166,9 @@ marko_template.meta = {
     id: "/@marko/webpack-tests$x.x.x/fixtures/basic-template-plugin-custom-runtime-id/test.marko",
     tags: [
       "./test.marko",
-      "marko/dist/core-tags/components/init-components-tag"
+      "marko/dist/core-tags/components/component-globals-tag",
+      "marko/dist/core-tags/components/init-components-tag",
+      "marko/dist/core-tags/core/await/reorderer-renderer"
     ]
   };
 
@@ -179,6 +187,17 @@ module.exports = http;
 
 /***/ }),
 
+/***/ "marko/dist/core-tags/components/component-globals-tag":
+/*!************************************************************************!*\
+  !*** external "marko/dist/core-tags/components/component-globals-tag" ***!
+  \************************************************************************/
+/*! no static exports found */
+/***/ (function(module, exports) {
+
+module.exports = marko/dist/core-tags/components/component-globals-tag;
+
+/***/ }),
+
 /***/ "marko/dist/core-tags/components/init-components-tag":
 /*!**********************************************************************!*\
   !*** external "marko/dist/core-tags/components/init-components-tag" ***!
@@ -187,6 +206,17 @@ module.exports = http;
 /***/ (function(module, exports) {
 
 module.exports = marko/dist/core-tags/components/init-components-tag;
+
+/***/ }),
+
+/***/ "marko/dist/core-tags/core/await/reorderer-renderer":
+/*!*********************************************************************!*\
+  !*** external "marko/dist/core-tags/core/await/reorderer-renderer" ***!
+  \*********************************************************************/
+/*! no static exports found */
+/***/ (function(module, exports) {
+
+module.exports = marko/dist/core-tags/core/await/reorderer-renderer;
 
 /***/ }),
 

--- a/src/__tests__/fixtures/basic-template-plugin/__snapshots__/server--main.js
+++ b/src/__tests__/fixtures/basic-template-plugin/__snapshots__/server--main.js
@@ -84,9 +84,11 @@ var marko_template = module.exports = __webpack_require__(/*! marko/dist/html */
     template = __webpack_require__(/*! ./test.marko */ "./src/__tests__/fixtures/basic-template-plugin/test.marko"),
     module_manifest = __webpack_require__(/*! ./../../../../__MARKO_WEBPACK__MANIFEST.js */ "./__MARKO_WEBPACK__MANIFEST.js"),
     manifest = module_manifest.default || module_manifest,
-    marko_dynamicTag = __webpack_require__(/*! marko/dist/runtime/helpers/dynamic-tag */ "marko/dist/runtime/helpers/dynamic-tag"),
     marko_loadTag = __webpack_require__(/*! marko/dist/runtime/helpers/load-tag */ "marko/dist/runtime/helpers/load-tag"),
-    init_components_tag = marko_loadTag(__webpack_require__(/*! marko/dist/core-tags/components/init-components-tag */ "marko/dist/core-tags/components/init-components-tag"));
+    component_globals_tag = marko_loadTag(__webpack_require__(/*! marko/dist/core-tags/components/component-globals-tag */ "marko/dist/core-tags/components/component-globals-tag")),
+    marko_dynamicTag = __webpack_require__(/*! marko/dist/runtime/helpers/dynamic-tag */ "marko/dist/runtime/helpers/dynamic-tag"),
+    init_components_tag = marko_loadTag(__webpack_require__(/*! marko/dist/core-tags/components/init-components-tag */ "marko/dist/core-tags/components/init-components-tag")),
+    await_reorderer_tag = marko_loadTag(__webpack_require__(/*! marko/dist/core-tags/core/await/reorderer-renderer */ "marko/dist/core-tags/core/await/reorderer-renderer"));
 
 function renderAssets() {
   const assets = this.___assets;
@@ -142,11 +144,15 @@ function render(input, out, __component, component, state) {
 
   out.end = outEndOverride;
 
+  component_globals_tag({}, out);
+
   marko_dynamicTag(out, template, function() {
     return input;
   }, null, null, null, __component, "0");
 
   init_components_tag({}, out);
+
+  await_reorderer_tag({}, out, __component, "1");
 }
 
 marko_template._ = marko_renderer(render, {
@@ -158,7 +164,9 @@ marko_template.meta = {
     id: "/@marko/webpack-tests$x.x.x/fixtures/basic-template-plugin/test.marko",
     tags: [
       "./test.marko",
-      "marko/dist/core-tags/components/init-components-tag"
+      "marko/dist/core-tags/components/component-globals-tag",
+      "marko/dist/core-tags/components/init-components-tag",
+      "marko/dist/core-tags/core/await/reorderer-renderer"
     ]
   };
 
@@ -177,6 +185,17 @@ module.exports = http;
 
 /***/ }),
 
+/***/ "marko/dist/core-tags/components/component-globals-tag":
+/*!************************************************************************!*\
+  !*** external "marko/dist/core-tags/components/component-globals-tag" ***!
+  \************************************************************************/
+/*! no static exports found */
+/***/ (function(module, exports) {
+
+module.exports = marko/dist/core-tags/components/component-globals-tag;
+
+/***/ }),
+
 /***/ "marko/dist/core-tags/components/init-components-tag":
 /*!**********************************************************************!*\
   !*** external "marko/dist/core-tags/components/init-components-tag" ***!
@@ -185,6 +204,17 @@ module.exports = http;
 /***/ (function(module, exports) {
 
 module.exports = marko/dist/core-tags/components/init-components-tag;
+
+/***/ }),
+
+/***/ "marko/dist/core-tags/core/await/reorderer-renderer":
+/*!*********************************************************************!*\
+  !*** external "marko/dist/core-tags/core/await/reorderer-renderer" ***!
+  \*********************************************************************/
+/*! no static exports found */
+/***/ (function(module, exports) {
+
+module.exports = marko/dist/core-tags/core/await/reorderer-renderer;
 
 /***/ }),
 

--- a/src/__tests__/fixtures/multiple-entries-plugin/__snapshots__/server--main.js
+++ b/src/__tests__/fixtures/multiple-entries-plugin/__snapshots__/server--main.js
@@ -73,9 +73,11 @@ var marko_template = module.exports = __webpack_require__(/*! marko/dist/html */
     template = __webpack_require__(/*! ./bar.marko */ "./src/__tests__/fixtures/multiple-entries-plugin/bar.marko"),
     module_manifest = __webpack_require__(/*! ./../../../../__MARKO_WEBPACK__MANIFEST.js */ "./__MARKO_WEBPACK__MANIFEST.js"),
     manifest = module_manifest.default || module_manifest,
-    marko_dynamicTag = __webpack_require__(/*! marko/dist/runtime/helpers/dynamic-tag */ "marko/dist/runtime/helpers/dynamic-tag"),
     marko_loadTag = __webpack_require__(/*! marko/dist/runtime/helpers/load-tag */ "marko/dist/runtime/helpers/load-tag"),
-    init_components_tag = marko_loadTag(__webpack_require__(/*! marko/dist/core-tags/components/init-components-tag */ "marko/dist/core-tags/components/init-components-tag"));
+    component_globals_tag = marko_loadTag(__webpack_require__(/*! marko/dist/core-tags/components/component-globals-tag */ "marko/dist/core-tags/components/component-globals-tag")),
+    marko_dynamicTag = __webpack_require__(/*! marko/dist/runtime/helpers/dynamic-tag */ "marko/dist/runtime/helpers/dynamic-tag"),
+    init_components_tag = marko_loadTag(__webpack_require__(/*! marko/dist/core-tags/components/init-components-tag */ "marko/dist/core-tags/components/init-components-tag")),
+    await_reorderer_tag = marko_loadTag(__webpack_require__(/*! marko/dist/core-tags/core/await/reorderer-renderer */ "marko/dist/core-tags/core/await/reorderer-renderer"));
 
 function renderAssets() {
   const assets = this.___assets;
@@ -131,11 +133,15 @@ function render(input, out, __component, component, state) {
 
   out.end = outEndOverride;
 
+  component_globals_tag({}, out);
+
   marko_dynamicTag(out, template, function() {
     return input;
   }, null, null, null, __component, "0");
 
   init_components_tag({}, out);
+
+  await_reorderer_tag({}, out, __component, "1");
 }
 
 marko_template._ = marko_renderer(render, {
@@ -147,7 +153,9 @@ marko_template.meta = {
     id: "/@marko/webpack-tests$x.x.x/fixtures/multiple-entries-plugin/bar.marko",
     tags: [
       "./bar.marko",
-      "marko/dist/core-tags/components/init-components-tag"
+      "marko/dist/core-tags/components/component-globals-tag",
+      "marko/dist/core-tags/components/init-components-tag",
+      "marko/dist/core-tags/core/await/reorderer-renderer"
     ]
   };
 
@@ -245,9 +253,11 @@ var marko_template = module.exports = __webpack_require__(/*! marko/dist/html */
     template = __webpack_require__(/*! ./foo.marko */ "./src/__tests__/fixtures/multiple-entries-plugin/foo.marko"),
     module_manifest = __webpack_require__(/*! ./../../../../__MARKO_WEBPACK__MANIFEST.js */ "./__MARKO_WEBPACK__MANIFEST.js"),
     manifest = module_manifest.default || module_manifest,
-    marko_dynamicTag = __webpack_require__(/*! marko/dist/runtime/helpers/dynamic-tag */ "marko/dist/runtime/helpers/dynamic-tag"),
     marko_loadTag = __webpack_require__(/*! marko/dist/runtime/helpers/load-tag */ "marko/dist/runtime/helpers/load-tag"),
-    init_components_tag = marko_loadTag(__webpack_require__(/*! marko/dist/core-tags/components/init-components-tag */ "marko/dist/core-tags/components/init-components-tag"));
+    component_globals_tag = marko_loadTag(__webpack_require__(/*! marko/dist/core-tags/components/component-globals-tag */ "marko/dist/core-tags/components/component-globals-tag")),
+    marko_dynamicTag = __webpack_require__(/*! marko/dist/runtime/helpers/dynamic-tag */ "marko/dist/runtime/helpers/dynamic-tag"),
+    init_components_tag = marko_loadTag(__webpack_require__(/*! marko/dist/core-tags/components/init-components-tag */ "marko/dist/core-tags/components/init-components-tag")),
+    await_reorderer_tag = marko_loadTag(__webpack_require__(/*! marko/dist/core-tags/core/await/reorderer-renderer */ "marko/dist/core-tags/core/await/reorderer-renderer"));
 
 function renderAssets() {
   const assets = this.___assets;
@@ -303,11 +313,15 @@ function render(input, out, __component, component, state) {
 
   out.end = outEndOverride;
 
+  component_globals_tag({}, out);
+
   marko_dynamicTag(out, template, function() {
     return input;
   }, null, null, null, __component, "0");
 
   init_components_tag({}, out);
+
+  await_reorderer_tag({}, out, __component, "1");
 }
 
 marko_template._ = marko_renderer(render, {
@@ -319,7 +333,9 @@ marko_template.meta = {
     id: "/@marko/webpack-tests$x.x.x/fixtures/multiple-entries-plugin/foo.marko",
     tags: [
       "./foo.marko",
-      "marko/dist/core-tags/components/init-components-tag"
+      "marko/dist/core-tags/components/component-globals-tag",
+      "marko/dist/core-tags/components/init-components-tag",
+      "marko/dist/core-tags/core/await/reorderer-renderer"
     ]
   };
 
@@ -359,6 +375,17 @@ module.exports = http;
 
 /***/ }),
 
+/***/ "marko/dist/core-tags/components/component-globals-tag":
+/*!************************************************************************!*\
+  !*** external "marko/dist/core-tags/components/component-globals-tag" ***!
+  \************************************************************************/
+/*! no static exports found */
+/***/ (function(module, exports) {
+
+module.exports = marko/dist/core-tags/components/component-globals-tag;
+
+/***/ }),
+
 /***/ "marko/dist/core-tags/components/init-components-tag":
 /*!**********************************************************************!*\
   !*** external "marko/dist/core-tags/components/init-components-tag" ***!
@@ -367,6 +394,17 @@ module.exports = http;
 /***/ (function(module, exports) {
 
 module.exports = marko/dist/core-tags/components/init-components-tag;
+
+/***/ }),
+
+/***/ "marko/dist/core-tags/core/await/reorderer-renderer":
+/*!*********************************************************************!*\
+  !*** external "marko/dist/core-tags/core/await/reorderer-renderer" ***!
+  \*********************************************************************/
+/*! no static exports found */
+/***/ (function(module, exports) {
+
+module.exports = marko/dist/core-tags/core/await/reorderer-renderer;
 
 /***/ }),
 

--- a/src/__tests__/fixtures/with-class-component-plugin-dynamic-bundle/__snapshots__/server--main.js
+++ b/src/__tests__/fixtures/with-class-component-plugin-dynamic-bundle/__snapshots__/server--main.js
@@ -146,9 +146,11 @@ var marko_template = module.exports = __webpack_require__(/*! marko/dist/html */
     template = __webpack_require__(/*! ./test.marko */ "./src/__tests__/fixtures/with-class-component-plugin-dynamic-bundle/test.marko"),
     module_manifest = __webpack_require__(/*! ./../../../../__MARKO_WEBPACK__MANIFEST.js */ "./__MARKO_WEBPACK__MANIFEST.js"),
     manifest = module_manifest.default || module_manifest,
-    marko_dynamicTag = __webpack_require__(/*! marko/dist/runtime/helpers/dynamic-tag */ "marko/dist/runtime/helpers/dynamic-tag"),
     marko_loadTag = __webpack_require__(/*! marko/dist/runtime/helpers/load-tag */ "marko/dist/runtime/helpers/load-tag"),
-    init_components_tag = marko_loadTag(__webpack_require__(/*! marko/dist/core-tags/components/init-components-tag */ "marko/dist/core-tags/components/init-components-tag"));
+    component_globals_tag = marko_loadTag(__webpack_require__(/*! marko/dist/core-tags/components/component-globals-tag */ "marko/dist/core-tags/components/component-globals-tag")),
+    marko_dynamicTag = __webpack_require__(/*! marko/dist/runtime/helpers/dynamic-tag */ "marko/dist/runtime/helpers/dynamic-tag"),
+    init_components_tag = marko_loadTag(__webpack_require__(/*! marko/dist/core-tags/components/init-components-tag */ "marko/dist/core-tags/components/init-components-tag")),
+    await_reorderer_tag = marko_loadTag(__webpack_require__(/*! marko/dist/core-tags/core/await/reorderer-renderer */ "marko/dist/core-tags/core/await/reorderer-renderer"));
 
 function renderAssets() {
   const assets = this.___assets;
@@ -204,11 +206,15 @@ function render(input, out, __component, component, state) {
 
   out.end = outEndOverride;
 
+  component_globals_tag({}, out);
+
   marko_dynamicTag(out, template, function() {
     return input;
   }, null, null, null, __component, "0");
 
   init_components_tag({}, out);
+
+  await_reorderer_tag({}, out, __component, "1");
 }
 
 marko_template._ = marko_renderer(render, {
@@ -220,7 +226,9 @@ marko_template.meta = {
     id: "/@marko/webpack-tests$x.x.x/fixtures/with-class-component-plugin-dynamic-bundle/test.marko",
     tags: [
       "./test.marko",
-      "marko/dist/core-tags/components/init-components-tag"
+      "marko/dist/core-tags/components/component-globals-tag",
+      "marko/dist/core-tags/components/init-components-tag",
+      "marko/dist/core-tags/core/await/reorderer-renderer"
     ]
   };
 
@@ -239,6 +247,17 @@ module.exports = http;
 
 /***/ }),
 
+/***/ "marko/dist/core-tags/components/component-globals-tag":
+/*!************************************************************************!*\
+  !*** external "marko/dist/core-tags/components/component-globals-tag" ***!
+  \************************************************************************/
+/*! no static exports found */
+/***/ (function(module, exports) {
+
+module.exports = marko/dist/core-tags/components/component-globals-tag;
+
+/***/ }),
+
 /***/ "marko/dist/core-tags/components/init-components-tag":
 /*!**********************************************************************!*\
   !*** external "marko/dist/core-tags/components/init-components-tag" ***!
@@ -247,6 +266,17 @@ module.exports = http;
 /***/ (function(module, exports) {
 
 module.exports = marko/dist/core-tags/components/init-components-tag;
+
+/***/ }),
+
+/***/ "marko/dist/core-tags/core/await/reorderer-renderer":
+/*!*********************************************************************!*\
+  !*** external "marko/dist/core-tags/core/await/reorderer-renderer" ***!
+  \*********************************************************************/
+/*! no static exports found */
+/***/ (function(module, exports) {
+
+module.exports = marko/dist/core-tags/core/await/reorderer-renderer;
 
 /***/ }),
 

--- a/src/__tests__/fixtures/with-class-component-plugin/__snapshots__/server--main.js
+++ b/src/__tests__/fixtures/with-class-component-plugin/__snapshots__/server--main.js
@@ -139,9 +139,11 @@ var marko_template = module.exports = __webpack_require__(/*! marko/dist/html */
     template = __webpack_require__(/*! ./test.marko */ "./src/__tests__/fixtures/with-class-component-plugin/test.marko"),
     module_manifest = __webpack_require__(/*! ./../../../../__MARKO_WEBPACK__MANIFEST.js */ "./__MARKO_WEBPACK__MANIFEST.js"),
     manifest = module_manifest.default || module_manifest,
-    marko_dynamicTag = __webpack_require__(/*! marko/dist/runtime/helpers/dynamic-tag */ "marko/dist/runtime/helpers/dynamic-tag"),
     marko_loadTag = __webpack_require__(/*! marko/dist/runtime/helpers/load-tag */ "marko/dist/runtime/helpers/load-tag"),
-    init_components_tag = marko_loadTag(__webpack_require__(/*! marko/dist/core-tags/components/init-components-tag */ "marko/dist/core-tags/components/init-components-tag"));
+    component_globals_tag = marko_loadTag(__webpack_require__(/*! marko/dist/core-tags/components/component-globals-tag */ "marko/dist/core-tags/components/component-globals-tag")),
+    marko_dynamicTag = __webpack_require__(/*! marko/dist/runtime/helpers/dynamic-tag */ "marko/dist/runtime/helpers/dynamic-tag"),
+    init_components_tag = marko_loadTag(__webpack_require__(/*! marko/dist/core-tags/components/init-components-tag */ "marko/dist/core-tags/components/init-components-tag")),
+    await_reorderer_tag = marko_loadTag(__webpack_require__(/*! marko/dist/core-tags/core/await/reorderer-renderer */ "marko/dist/core-tags/core/await/reorderer-renderer"));
 
 function renderAssets() {
   const assets = this.___assets;
@@ -197,11 +199,15 @@ function render(input, out, __component, component, state) {
 
   out.end = outEndOverride;
 
+  component_globals_tag({}, out);
+
   marko_dynamicTag(out, template, function() {
     return input;
   }, null, null, null, __component, "0");
 
   init_components_tag({}, out);
+
+  await_reorderer_tag({}, out, __component, "1");
 }
 
 marko_template._ = marko_renderer(render, {
@@ -213,7 +219,9 @@ marko_template.meta = {
     id: "/@marko/webpack-tests$x.x.x/fixtures/with-class-component-plugin/test.marko",
     tags: [
       "./test.marko",
-      "marko/dist/core-tags/components/init-components-tag"
+      "marko/dist/core-tags/components/component-globals-tag",
+      "marko/dist/core-tags/components/init-components-tag",
+      "marko/dist/core-tags/core/await/reorderer-renderer"
     ]
   };
 
@@ -232,6 +240,17 @@ module.exports = http;
 
 /***/ }),
 
+/***/ "marko/dist/core-tags/components/component-globals-tag":
+/*!************************************************************************!*\
+  !*** external "marko/dist/core-tags/components/component-globals-tag" ***!
+  \************************************************************************/
+/*! no static exports found */
+/***/ (function(module, exports) {
+
+module.exports = marko/dist/core-tags/components/component-globals-tag;
+
+/***/ }),
+
 /***/ "marko/dist/core-tags/components/init-components-tag":
 /*!**********************************************************************!*\
   !*** external "marko/dist/core-tags/components/init-components-tag" ***!
@@ -240,6 +259,17 @@ module.exports = http;
 /***/ (function(module, exports) {
 
 module.exports = marko/dist/core-tags/components/init-components-tag;
+
+/***/ }),
+
+/***/ "marko/dist/core-tags/core/await/reorderer-renderer":
+/*!*********************************************************************!*\
+  !*** external "marko/dist/core-tags/core/await/reorderer-renderer" ***!
+  \*********************************************************************/
+/*! no static exports found */
+/***/ (function(module, exports) {
+
+module.exports = marko/dist/core-tags/core/await/reorderer-renderer;
 
 /***/ }),
 

--- a/src/__tests__/fixtures/with-public-path/__snapshots__/server--main.js
+++ b/src/__tests__/fixtures/with-public-path/__snapshots__/server--main.js
@@ -84,9 +84,11 @@ var marko_template = module.exports = __webpack_require__(/*! marko/dist/html */
     template = __webpack_require__(/*! ./test.marko */ "./src/__tests__/fixtures/with-public-path/test.marko"),
     module_manifest = __webpack_require__(/*! ./../../../../__MARKO_WEBPACK__MANIFEST.js */ "./__MARKO_WEBPACK__MANIFEST.js"),
     manifest = module_manifest.default || module_manifest,
-    marko_dynamicTag = __webpack_require__(/*! marko/dist/runtime/helpers/dynamic-tag */ "marko/dist/runtime/helpers/dynamic-tag"),
     marko_loadTag = __webpack_require__(/*! marko/dist/runtime/helpers/load-tag */ "marko/dist/runtime/helpers/load-tag"),
-    init_components_tag = marko_loadTag(__webpack_require__(/*! marko/dist/core-tags/components/init-components-tag */ "marko/dist/core-tags/components/init-components-tag"));
+    component_globals_tag = marko_loadTag(__webpack_require__(/*! marko/dist/core-tags/components/component-globals-tag */ "marko/dist/core-tags/components/component-globals-tag")),
+    marko_dynamicTag = __webpack_require__(/*! marko/dist/runtime/helpers/dynamic-tag */ "marko/dist/runtime/helpers/dynamic-tag"),
+    init_components_tag = marko_loadTag(__webpack_require__(/*! marko/dist/core-tags/components/init-components-tag */ "marko/dist/core-tags/components/init-components-tag")),
+    await_reorderer_tag = marko_loadTag(__webpack_require__(/*! marko/dist/core-tags/core/await/reorderer-renderer */ "marko/dist/core-tags/core/await/reorderer-renderer"));
 
 function renderAssets() {
   const assets = this.___assets;
@@ -142,11 +144,15 @@ function render(input, out, __component, component, state) {
 
   out.end = outEndOverride;
 
+  component_globals_tag({}, out);
+
   marko_dynamicTag(out, template, function() {
     return input;
   }, null, null, null, __component, "0");
 
   init_components_tag({}, out);
+
+  await_reorderer_tag({}, out, __component, "1");
 }
 
 marko_template._ = marko_renderer(render, {
@@ -158,7 +164,9 @@ marko_template.meta = {
     id: "/@marko/webpack-tests$x.x.x/fixtures/with-public-path/test.marko",
     tags: [
       "./test.marko",
-      "marko/dist/core-tags/components/init-components-tag"
+      "marko/dist/core-tags/components/component-globals-tag",
+      "marko/dist/core-tags/components/init-components-tag",
+      "marko/dist/core-tags/core/await/reorderer-renderer"
     ]
   };
 
@@ -177,6 +185,17 @@ module.exports = http;
 
 /***/ }),
 
+/***/ "marko/dist/core-tags/components/component-globals-tag":
+/*!************************************************************************!*\
+  !*** external "marko/dist/core-tags/components/component-globals-tag" ***!
+  \************************************************************************/
+/*! no static exports found */
+/***/ (function(module, exports) {
+
+module.exports = marko/dist/core-tags/components/component-globals-tag;
+
+/***/ }),
+
 /***/ "marko/dist/core-tags/components/init-components-tag":
 /*!**********************************************************************!*\
   !*** external "marko/dist/core-tags/components/init-components-tag" ***!
@@ -185,6 +204,17 @@ module.exports = http;
 /***/ (function(module, exports) {
 
 module.exports = marko/dist/core-tags/components/init-components-tag;
+
+/***/ }),
+
+/***/ "marko/dist/core-tags/core/await/reorderer-renderer":
+/*!*********************************************************************!*\
+  !*** external "marko/dist/core-tags/core/await/reorderer-renderer" ***!
+  \*********************************************************************/
+/*! no static exports found */
+/***/ (function(module, exports) {
+
+module.exports = marko/dist/core-tags/core/await/reorderer-renderer;
 
 /***/ }),
 

--- a/src/loader/get-asset-code.ts
+++ b/src/loader/get-asset-code.ts
@@ -71,6 +71,8 @@ $ out.___assets = manifest.getAssets(${JSON.stringify(
 $ out.flush = outFlushOverride;
 $ out.end = outEndOverride;
 
+<component-globals/>
 <\${template} ...input/>
 <init-components/>
+<await-reorderer/>
 `;


### PR DESCRIPTION
## Description

Currently the `<component-globals>` (handles serializing `$global` data in input) and the `<await-reorderer>` (handles out of order flushing) are not included in the generated asset template for the server side bundle when using the plugin. These tags are automatically pulled in if a `<body>` tag is present, however now they will always be pulled in automatically.

This is particularly useful if you are using Marko to render snippets of html from the server.

## Checklist:

- [ ] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.
