### PR TITLE
Snapshot fixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1110,9 +1110,9 @@
       }
     },
     "@types/eslint": {
-      "version": "7.2.6",
-      "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-7.2.6.tgz",
-      "integrity": "sha512-I+1sYH+NPQ3/tVqCeUSBwTE/0heyvtXqpIopUUArlBm0Kpocb8FbMa3AZ/ASKIFpN3rnEx932TTXDbt9OXsNDw==",
+      "version": "7.2.7",
+      "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-7.2.7.tgz",
+      "integrity": "sha512-EHXbc1z2GoQRqHaAT7+grxlTJ3WE2YNeD6jlpPoRc83cCoThRY+NUWjCUZaYmk51OICkPXn2hhphcWcWXgNW0Q==",
       "dev": true,
       "requires": {
         "@types/estree": "*",
@@ -2101,6 +2101,16 @@
       "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
       "dev": true,
       "optional": true
+    },
+    "bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "file-uri-to-path": "1.0.0"
+      }
     },
     "bluebird": {
       "version": "3.7.2",
@@ -3786,9 +3796,9 @@
       }
     },
     "es-module-lexer": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-0.4.0.tgz",
-      "integrity": "sha512-iuEGihqqhKWFgh72Q/Jtch7V2t/ft8w8IPP2aEN8ArYKO+IWyo6hsi96hCdgyeEDQIV3InhYQ9BlwUFPGXrbEQ==",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-0.4.1.tgz",
+      "integrity": "sha512-ooYciCUtfw6/d2w56UVeqHPcoCFAiJdz5XOkYpv/Txl1HMUozpXjz/2RIQgqwKdXNDPSF1W7mJCFse3G+HDyAA==",
       "dev": true
     },
     "escalade": {
@@ -4411,6 +4421,13 @@
       "requires": {
         "flat-cache": "^3.0.4"
       }
+    },
+    "file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "dev": true,
+      "optional": true
     },
     "filename-reserved-regex": {
       "version": "2.0.0",
@@ -7160,6 +7177,13 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
       "dev": true
+    },
+    "nan": {
+      "version": "2.14.2",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.2.tgz",
+      "integrity": "sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ==",
+      "dev": true,
+      "optional": true
     },
     "nanoid": {
       "version": "3.1.20",
@@ -10271,7 +10295,11 @@
           "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
           "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "bindings": "^1.5.0",
+            "nan": "^2.12.1"
+          }
         },
         "glob-parent": {
           "version": "3.1.0",
@@ -10688,9 +10716,9 @@
       }
     },
     "webpack5": {
-      "version": "npm:webpack@5.24.2",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.24.2.tgz",
-      "integrity": "sha512-uxxKYEY4kMNjP+D2Y+8aw5Vd7ar4pMuKCNemxV26ysr1nk0YDiQTylg9U3VZIdkmI0YHa0uC8ABxL+uGxGWWJg==",
+      "version": "npm:webpack@5.25.0",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.25.0.tgz",
+      "integrity": "sha512-jqQZopNCzt9c4K6Qa7j6kIhzHfR9wgF84go58VoNp4JbZrBr2D2l5lcv72CW80yc6NJl8CR6OY8xctnIs0r2uw==",
       "dev": true,
       "requires": {
         "@types/eslint-scope": "^3.7.0",
@@ -10848,9 +10876,9 @@
           }
         },
         "acorn": {
-          "version": "8.0.5",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.0.5.tgz",
-          "integrity": "sha512-v+DieK/HJkJOpFBETDJioequtc3PfxsWMaxIdIwujtF7FEV/MAyDQLlm6/zPvr7Mix07mLh6ccVwIsloceodlg==",
+          "version": "8.1.0",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.1.0.tgz",
+          "integrity": "sha512-LWCF/Wn0nfHOmJ9rzQApGnxnvgfROzGilS8936rqN/lfcYkY9MYZzdMqN+2NJ4SlTc+m5HiSa+kNfDtI64dwUA==",
           "dev": true
         },
         "commander": {

--- a/src/__tests__/fixtures/asset-tag/__snapshots__/webpack4/server--main.js
+++ b/src/__tests__/fixtures/asset-tag/__snapshots__/webpack4/server--main.js
@@ -358,7 +358,7 @@ __webpack_require__.r(__webpack_exports__);
 /*! no static exports found */
 /***/ (function(module, exports) {
 
-module.exports = http;
+module.exports = require("http");
 
 /***/ }),
 
@@ -369,7 +369,7 @@ module.exports = http;
 /*! no static exports found */
 /***/ (function(module, exports) {
 
-module.exports = marko/dist/core-tags/components/init-components-tag.js;
+module.exports = require("marko/dist/core-tags/components/init-components-tag.js");
 
 /***/ }),
 
@@ -380,7 +380,7 @@ module.exports = marko/dist/core-tags/components/init-components-tag.js;
 /*! no static exports found */
 /***/ (function(module, exports) {
 
-module.exports = marko/dist/core-tags/core/await/reorderer-renderer.js;
+module.exports = require("marko/dist/core-tags/core/await/reorderer-renderer.js");
 
 /***/ }),
 
@@ -391,7 +391,7 @@ module.exports = marko/dist/core-tags/core/await/reorderer-renderer.js;
 /*! no static exports found */
 /***/ (function(module, exports) {
 
-module.exports = marko/dist/runtime/components/renderer;
+module.exports = require("marko/dist/runtime/components/renderer");
 
 /***/ }),
 
@@ -402,7 +402,7 @@ module.exports = marko/dist/runtime/components/renderer;
 /*! no static exports found */
 /***/ (function(module, exports) {
 
-module.exports = marko/dist/runtime/helpers/render-tag;
+module.exports = require("marko/dist/runtime/helpers/render-tag");
 
 /***/ }),
 
@@ -413,7 +413,7 @@ module.exports = marko/dist/runtime/helpers/render-tag;
 /*! no static exports found */
 /***/ (function(module, exports) {
 
-module.exports = marko/dist/runtime/html;
+module.exports = require("marko/dist/runtime/html");
 
 /***/ }),
 
@@ -424,7 +424,7 @@ module.exports = marko/dist/runtime/html;
 /*! no static exports found */
 /***/ (function(module, exports) {
 
-module.exports = marko/dist/runtime/html/helpers/attr;
+module.exports = require("marko/dist/runtime/html/helpers/attr");
 
 /***/ }),
 
@@ -435,7 +435,7 @@ module.exports = marko/dist/runtime/html/helpers/attr;
 /*! no static exports found */
 /***/ (function(module, exports) {
 
-module.exports = marko/dist/runtime/html/helpers/attrs;
+module.exports = require("marko/dist/runtime/html/helpers/attrs");
 
 /***/ })
 

--- a/src/__tests__/fixtures/asset-tag/__snapshots__/webpack5/server--main.js
+++ b/src/__tests__/fixtures/asset-tag/__snapshots__/webpack5/server--main.js
@@ -273,7 +273,7 @@ module.exports = require("http");;
 /***/ ((module) => {
 
 "use strict";
-module.exports = marko/dist/core-tags/components/init-components-tag.js;
+module.exports = require("marko/dist/core-tags/components/init-components-tag.js");;
 
 /***/ }),
 
@@ -284,7 +284,7 @@ module.exports = marko/dist/core-tags/components/init-components-tag.js;
 /***/ ((module) => {
 
 "use strict";
-module.exports = marko/dist/core-tags/core/await/reorderer-renderer.js;
+module.exports = require("marko/dist/core-tags/core/await/reorderer-renderer.js");;
 
 /***/ }),
 
@@ -295,7 +295,7 @@ module.exports = marko/dist/core-tags/core/await/reorderer-renderer.js;
 /***/ ((module) => {
 
 "use strict";
-module.exports = marko/dist/runtime/components/renderer;
+module.exports = require("marko/dist/runtime/components/renderer");;
 
 /***/ }),
 
@@ -306,7 +306,7 @@ module.exports = marko/dist/runtime/components/renderer;
 /***/ ((module) => {
 
 "use strict";
-module.exports = marko/dist/runtime/helpers/render-tag;
+module.exports = require("marko/dist/runtime/helpers/render-tag");;
 
 /***/ }),
 
@@ -317,7 +317,7 @@ module.exports = marko/dist/runtime/helpers/render-tag;
 /***/ ((module) => {
 
 "use strict";
-module.exports = marko/dist/runtime/html;
+module.exports = require("marko/dist/runtime/html");;
 
 /***/ }),
 
@@ -328,7 +328,7 @@ module.exports = marko/dist/runtime/html;
 /***/ ((module) => {
 
 "use strict";
-module.exports = marko/dist/runtime/html/helpers/attr;
+module.exports = require("marko/dist/runtime/html/helpers/attr");;
 
 /***/ }),
 
@@ -339,7 +339,7 @@ module.exports = marko/dist/runtime/html/helpers/attr;
 /***/ ((module) => {
 
 "use strict";
-module.exports = marko/dist/runtime/html/helpers/attrs;
+module.exports = require("marko/dist/runtime/html/helpers/attrs");;
 
 /***/ })
 

--- a/src/__tests__/fixtures/asset-tag/__snapshots__/webpack5/server--main.js
+++ b/src/__tests__/fixtures/asset-tag/__snapshots__/webpack5/server--main.js
@@ -351,8 +351,9 @@ module.exports = require("marko/dist/runtime/html/helpers/attrs");;
 /******/ 	// The require function
 /******/ 	function __webpack_require__(moduleId) {
 /******/ 		// Check if module is in cache
-/******/ 		if(__webpack_module_cache__[moduleId]) {
-/******/ 			return __webpack_module_cache__[moduleId].exports;
+/******/ 		var cachedModule = __webpack_module_cache__[moduleId];
+/******/ 		if (cachedModule !== undefined) {
+/******/ 			return cachedModule.exports;
 /******/ 		}
 /******/ 		// Create a new module (and put it into the cache)
 /******/ 		var module = __webpack_module_cache__[moduleId] = {

--- a/src/__tests__/fixtures/basic-template-plugin-custom-runtime-id/__snapshots__/webpack4/browser--test_8XgZ.js
+++ b/src/__tests__/fixtures/basic-template-plugin-custom-runtime-id/__snapshots__/webpack4/browser--test_8XgZ.js
@@ -125,7 +125,7 @@ Object(marko_components__WEBPACK_IMPORTED_MODULE_1__["init"])("testruntime");
 /*! no static exports found */
 /***/ (function(module, exports) {
 
-module.exports = marko/components;
+module.exports = require("marko/components");
 
 /***/ })
 

--- a/src/__tests__/fixtures/basic-template-plugin-custom-runtime-id/__snapshots__/webpack4/server--main.js
+++ b/src/__tests__/fixtures/basic-template-plugin-custom-runtime-id/__snapshots__/webpack4/server--main.js
@@ -281,7 +281,7 @@ __webpack_require__.r(__webpack_exports__);
 /*! no static exports found */
 /***/ (function(module, exports) {
 
-module.exports = http;
+module.exports = require("http");
 
 /***/ }),
 
@@ -292,7 +292,7 @@ module.exports = http;
 /*! no static exports found */
 /***/ (function(module, exports) {
 
-module.exports = marko/dist/core-tags/components/init-components-tag.js;
+module.exports = require("marko/dist/core-tags/components/init-components-tag.js");
 
 /***/ }),
 
@@ -303,7 +303,7 @@ module.exports = marko/dist/core-tags/components/init-components-tag.js;
 /*! no static exports found */
 /***/ (function(module, exports) {
 
-module.exports = marko/dist/core-tags/core/await/reorderer-renderer.js;
+module.exports = require("marko/dist/core-tags/core/await/reorderer-renderer.js");
 
 /***/ }),
 
@@ -314,7 +314,7 @@ module.exports = marko/dist/core-tags/core/await/reorderer-renderer.js;
 /*! no static exports found */
 /***/ (function(module, exports) {
 
-module.exports = marko/dist/runtime/components/renderer;
+module.exports = require("marko/dist/runtime/components/renderer");
 
 /***/ }),
 
@@ -325,7 +325,7 @@ module.exports = marko/dist/runtime/components/renderer;
 /*! no static exports found */
 /***/ (function(module, exports) {
 
-module.exports = marko/dist/runtime/helpers/render-tag;
+module.exports = require("marko/dist/runtime/helpers/render-tag");
 
 /***/ }),
 
@@ -336,7 +336,7 @@ module.exports = marko/dist/runtime/helpers/render-tag;
 /*! no static exports found */
 /***/ (function(module, exports) {
 
-module.exports = marko/dist/runtime/html;
+module.exports = require("marko/dist/runtime/html");
 
 /***/ })
 

--- a/src/__tests__/fixtures/basic-template-plugin-custom-runtime-id/__snapshots__/webpack5/browser--test_8XgZ.js
+++ b/src/__tests__/fixtures/basic-template-plugin-custom-runtime-id/__snapshots__/webpack5/browser--test_8XgZ.js
@@ -8,7 +8,7 @@
   \***********************************/
 /***/ ((module) => {
 
-module.exports = marko/components;
+module.exports = require("marko/components");;
 
 /***/ })
 

--- a/src/__tests__/fixtures/basic-template-plugin-custom-runtime-id/__snapshots__/webpack5/browser--test_8XgZ.js
+++ b/src/__tests__/fixtures/basic-template-plugin-custom-runtime-id/__snapshots__/webpack5/browser--test_8XgZ.js
@@ -20,8 +20,9 @@ module.exports = require("marko/components");;
 /******/ 	// The require function
 /******/ 	function __webpack_require__(moduleId) {
 /******/ 		// Check if module is in cache
-/******/ 		if(__webpack_module_cache__[moduleId]) {
-/******/ 			return __webpack_module_cache__[moduleId].exports;
+/******/ 		var cachedModule = __webpack_module_cache__[moduleId];
+/******/ 		if (cachedModule !== undefined) {
+/******/ 			return cachedModule.exports;
 /******/ 		}
 /******/ 		// Create a new module (and put it into the cache)
 /******/ 		var module = __webpack_module_cache__[moduleId] = {

--- a/src/__tests__/fixtures/basic-template-plugin-custom-runtime-id/__snapshots__/webpack5/server--main.js
+++ b/src/__tests__/fixtures/basic-template-plugin-custom-runtime-id/__snapshots__/webpack5/server--main.js
@@ -250,8 +250,9 @@ module.exports = require("marko/dist/runtime/html");;
 /******/ 	// The require function
 /******/ 	function __webpack_require__(moduleId) {
 /******/ 		// Check if module is in cache
-/******/ 		if(__webpack_module_cache__[moduleId]) {
-/******/ 			return __webpack_module_cache__[moduleId].exports;
+/******/ 		var cachedModule = __webpack_module_cache__[moduleId];
+/******/ 		if (cachedModule !== undefined) {
+/******/ 			return cachedModule.exports;
 /******/ 		}
 /******/ 		// Create a new module (and put it into the cache)
 /******/ 		var module = __webpack_module_cache__[moduleId] = {

--- a/src/__tests__/fixtures/basic-template-plugin-custom-runtime-id/__snapshots__/webpack5/server--main.js
+++ b/src/__tests__/fixtures/basic-template-plugin-custom-runtime-id/__snapshots__/webpack5/server--main.js
@@ -194,7 +194,7 @@ module.exports = require("http");;
 /***/ ((module) => {
 
 "use strict";
-module.exports = marko/dist/core-tags/components/init-components-tag.js;
+module.exports = require("marko/dist/core-tags/components/init-components-tag.js");;
 
 /***/ }),
 
@@ -205,7 +205,7 @@ module.exports = marko/dist/core-tags/components/init-components-tag.js;
 /***/ ((module) => {
 
 "use strict";
-module.exports = marko/dist/core-tags/core/await/reorderer-renderer.js;
+module.exports = require("marko/dist/core-tags/core/await/reorderer-renderer.js");;
 
 /***/ }),
 
@@ -216,7 +216,7 @@ module.exports = marko/dist/core-tags/core/await/reorderer-renderer.js;
 /***/ ((module) => {
 
 "use strict";
-module.exports = marko/dist/runtime/components/renderer;
+module.exports = require("marko/dist/runtime/components/renderer");;
 
 /***/ }),
 
@@ -227,7 +227,7 @@ module.exports = marko/dist/runtime/components/renderer;
 /***/ ((module) => {
 
 "use strict";
-module.exports = marko/dist/runtime/helpers/render-tag;
+module.exports = require("marko/dist/runtime/helpers/render-tag");;
 
 /***/ }),
 
@@ -238,7 +238,7 @@ module.exports = marko/dist/runtime/helpers/render-tag;
 /***/ ((module) => {
 
 "use strict";
-module.exports = marko/dist/runtime/html;
+module.exports = require("marko/dist/runtime/html");;
 
 /***/ })
 

--- a/src/__tests__/fixtures/basic-template-plugin/__snapshots__/webpack4/server--main.js
+++ b/src/__tests__/fixtures/basic-template-plugin/__snapshots__/webpack4/server--main.js
@@ -280,7 +280,7 @@ __webpack_require__.r(__webpack_exports__);
 /*! no static exports found */
 /***/ (function(module, exports) {
 
-module.exports = http;
+module.exports = require("http");
 
 /***/ }),
 
@@ -291,7 +291,7 @@ module.exports = http;
 /*! no static exports found */
 /***/ (function(module, exports) {
 
-module.exports = marko/dist/core-tags/components/init-components-tag.js;
+module.exports = require("marko/dist/core-tags/components/init-components-tag.js");
 
 /***/ }),
 
@@ -302,7 +302,7 @@ module.exports = marko/dist/core-tags/components/init-components-tag.js;
 /*! no static exports found */
 /***/ (function(module, exports) {
 
-module.exports = marko/dist/core-tags/core/await/reorderer-renderer.js;
+module.exports = require("marko/dist/core-tags/core/await/reorderer-renderer.js");
 
 /***/ }),
 
@@ -313,7 +313,7 @@ module.exports = marko/dist/core-tags/core/await/reorderer-renderer.js;
 /*! no static exports found */
 /***/ (function(module, exports) {
 
-module.exports = marko/dist/runtime/components/renderer;
+module.exports = require("marko/dist/runtime/components/renderer");
 
 /***/ }),
 
@@ -324,7 +324,7 @@ module.exports = marko/dist/runtime/components/renderer;
 /*! no static exports found */
 /***/ (function(module, exports) {
 
-module.exports = marko/dist/runtime/helpers/render-tag;
+module.exports = require("marko/dist/runtime/helpers/render-tag");
 
 /***/ }),
 
@@ -335,7 +335,7 @@ module.exports = marko/dist/runtime/helpers/render-tag;
 /*! no static exports found */
 /***/ (function(module, exports) {
 
-module.exports = marko/dist/runtime/html;
+module.exports = require("marko/dist/runtime/html");
 
 /***/ })
 

--- a/src/__tests__/fixtures/basic-template-plugin/__snapshots__/webpack5/server--main.js
+++ b/src/__tests__/fixtures/basic-template-plugin/__snapshots__/webpack5/server--main.js
@@ -249,8 +249,9 @@ module.exports = require("marko/dist/runtime/html");;
 /******/ 	// The require function
 /******/ 	function __webpack_require__(moduleId) {
 /******/ 		// Check if module is in cache
-/******/ 		if(__webpack_module_cache__[moduleId]) {
-/******/ 			return __webpack_module_cache__[moduleId].exports;
+/******/ 		var cachedModule = __webpack_module_cache__[moduleId];
+/******/ 		if (cachedModule !== undefined) {
+/******/ 			return cachedModule.exports;
 /******/ 		}
 /******/ 		// Create a new module (and put it into the cache)
 /******/ 		var module = __webpack_module_cache__[moduleId] = {

--- a/src/__tests__/fixtures/basic-template-plugin/__snapshots__/webpack5/server--main.js
+++ b/src/__tests__/fixtures/basic-template-plugin/__snapshots__/webpack5/server--main.js
@@ -193,7 +193,7 @@ module.exports = require("http");;
 /***/ ((module) => {
 
 "use strict";
-module.exports = marko/dist/core-tags/components/init-components-tag.js;
+module.exports = require("marko/dist/core-tags/components/init-components-tag.js");;
 
 /***/ }),
 
@@ -204,7 +204,7 @@ module.exports = marko/dist/core-tags/components/init-components-tag.js;
 /***/ ((module) => {
 
 "use strict";
-module.exports = marko/dist/core-tags/core/await/reorderer-renderer.js;
+module.exports = require("marko/dist/core-tags/core/await/reorderer-renderer.js");;
 
 /***/ }),
 
@@ -215,7 +215,7 @@ module.exports = marko/dist/core-tags/core/await/reorderer-renderer.js;
 /***/ ((module) => {
 
 "use strict";
-module.exports = marko/dist/runtime/components/renderer;
+module.exports = require("marko/dist/runtime/components/renderer");;
 
 /***/ }),
 
@@ -226,7 +226,7 @@ module.exports = marko/dist/runtime/components/renderer;
 /***/ ((module) => {
 
 "use strict";
-module.exports = marko/dist/runtime/helpers/render-tag;
+module.exports = require("marko/dist/runtime/helpers/render-tag");;
 
 /***/ }),
 
@@ -237,7 +237,7 @@ module.exports = marko/dist/runtime/helpers/render-tag;
 /***/ ((module) => {
 
 "use strict";
-module.exports = marko/dist/runtime/html;
+module.exports = require("marko/dist/runtime/html");;
 
 /***/ })
 

--- a/src/__tests__/fixtures/basic-template/__snapshots__/webpack4/main.js
+++ b/src/__tests__/fixtures/basic-template/__snapshots__/webpack4/main.js
@@ -137,7 +137,7 @@ _marko_template.Component = marko_dist_runtime_components_defineComponent__WEBPA
 /*! no static exports found */
 /***/ (function(module, exports) {
 
-module.exports = marko/dist/runtime/components/defineComponent;
+module.exports = require("marko/dist/runtime/components/defineComponent");
 
 /***/ }),
 
@@ -148,7 +148,7 @@ module.exports = marko/dist/runtime/components/defineComponent;
 /*! no static exports found */
 /***/ (function(module, exports) {
 
-module.exports = marko/dist/runtime/components/registry-browser;
+module.exports = require("marko/dist/runtime/components/registry-browser");
 
 /***/ }),
 
@@ -159,7 +159,7 @@ module.exports = marko/dist/runtime/components/registry-browser;
 /*! no static exports found */
 /***/ (function(module, exports) {
 
-module.exports = marko/dist/runtime/components/renderer;
+module.exports = require("marko/dist/runtime/components/renderer");
 
 /***/ }),
 
@@ -170,7 +170,7 @@ module.exports = marko/dist/runtime/components/renderer;
 /*! no static exports found */
 /***/ (function(module, exports) {
 
-module.exports = marko/dist/runtime/vdom;
+module.exports = require("marko/dist/runtime/vdom");
 
 /***/ }),
 
@@ -181,7 +181,7 @@ module.exports = marko/dist/runtime/vdom;
 /*! no static exports found */
 /***/ (function(module, exports) {
 
-module.exports = marko/dist/runtime/vdom/helpers/v-element;
+module.exports = require("marko/dist/runtime/vdom/helpers/v-element");
 
 /***/ })
 

--- a/src/__tests__/fixtures/basic-template/__snapshots__/webpack5/main.js
+++ b/src/__tests__/fixtures/basic-template/__snapshots__/webpack5/main.js
@@ -60,8 +60,9 @@ module.exports = require("marko/dist/runtime/vdom/helpers/v-element");;
 /******/ 	// The require function
 /******/ 	function __webpack_require__(moduleId) {
 /******/ 		// Check if module is in cache
-/******/ 		if(__webpack_module_cache__[moduleId]) {
-/******/ 			return __webpack_module_cache__[moduleId].exports;
+/******/ 		var cachedModule = __webpack_module_cache__[moduleId];
+/******/ 		if (cachedModule !== undefined) {
+/******/ 			return cachedModule.exports;
 /******/ 		}
 /******/ 		// Create a new module (and put it into the cache)
 /******/ 		var module = __webpack_module_cache__[moduleId] = {

--- a/src/__tests__/fixtures/basic-template/__snapshots__/webpack5/main.js
+++ b/src/__tests__/fixtures/basic-template/__snapshots__/webpack5/main.js
@@ -8,7 +8,7 @@
   \****************************************************************/
 /***/ ((module) => {
 
-module.exports = marko/dist/runtime/components/defineComponent;
+module.exports = require("marko/dist/runtime/components/defineComponent");;
 
 /***/ }),
 
@@ -18,7 +18,7 @@ module.exports = marko/dist/runtime/components/defineComponent;
   \*****************************************************************/
 /***/ ((module) => {
 
-module.exports = marko/dist/runtime/components/registry-browser;
+module.exports = require("marko/dist/runtime/components/registry-browser");;
 
 /***/ }),
 
@@ -28,7 +28,7 @@ module.exports = marko/dist/runtime/components/registry-browser;
   \*********************************************************/
 /***/ ((module) => {
 
-module.exports = marko/dist/runtime/components/renderer;
+module.exports = require("marko/dist/runtime/components/renderer");;
 
 /***/ }),
 
@@ -38,7 +38,7 @@ module.exports = marko/dist/runtime/components/renderer;
   \******************************************/
 /***/ ((module) => {
 
-module.exports = marko/dist/runtime/vdom;
+module.exports = require("marko/dist/runtime/vdom");;
 
 /***/ }),
 
@@ -48,7 +48,7 @@ module.exports = marko/dist/runtime/vdom;
   \************************************************************/
 /***/ ((module) => {
 
-module.exports = marko/dist/runtime/vdom/helpers/v-element;
+module.exports = require("marko/dist/runtime/vdom/helpers/v-element");;
 
 /***/ })
 

--- a/src/__tests__/fixtures/multiple-entries-plugin/__snapshots__/webpack4/server--main.js
+++ b/src/__tests__/fixtures/multiple-entries-plugin/__snapshots__/webpack4/server--main.js
@@ -634,7 +634,7 @@ __webpack_require__.r(__webpack_exports__);
 /*! no static exports found */
 /***/ (function(module, exports) {
 
-module.exports = http;
+module.exports = require("http");
 
 /***/ }),
 
@@ -645,7 +645,7 @@ module.exports = http;
 /*! no static exports found */
 /***/ (function(module, exports) {
 
-module.exports = marko/dist/core-tags/components/init-components-tag.js;
+module.exports = require("marko/dist/core-tags/components/init-components-tag.js");
 
 /***/ }),
 
@@ -656,7 +656,7 @@ module.exports = marko/dist/core-tags/components/init-components-tag.js;
 /*! no static exports found */
 /***/ (function(module, exports) {
 
-module.exports = marko/dist/core-tags/core/await/reorderer-renderer.js;
+module.exports = require("marko/dist/core-tags/core/await/reorderer-renderer.js");
 
 /***/ }),
 
@@ -667,7 +667,7 @@ module.exports = marko/dist/core-tags/core/await/reorderer-renderer.js;
 /*! no static exports found */
 /***/ (function(module, exports) {
 
-module.exports = marko/dist/runtime/components/renderer;
+module.exports = require("marko/dist/runtime/components/renderer");
 
 /***/ }),
 
@@ -678,7 +678,7 @@ module.exports = marko/dist/runtime/components/renderer;
 /*! no static exports found */
 /***/ (function(module, exports) {
 
-module.exports = marko/dist/runtime/helpers/render-tag;
+module.exports = require("marko/dist/runtime/helpers/render-tag");
 
 /***/ }),
 
@@ -689,7 +689,7 @@ module.exports = marko/dist/runtime/helpers/render-tag;
 /*! no static exports found */
 /***/ (function(module, exports) {
 
-module.exports = marko/dist/runtime/html;
+module.exports = require("marko/dist/runtime/html");
 
 /***/ })
 

--- a/src/__tests__/fixtures/multiple-entries-plugin/__snapshots__/webpack5/server--main.js
+++ b/src/__tests__/fixtures/multiple-entries-plugin/__snapshots__/webpack5/server--main.js
@@ -553,7 +553,7 @@ module.exports = require("http");;
 /***/ ((module) => {
 
 "use strict";
-module.exports = marko/dist/core-tags/components/init-components-tag.js;
+module.exports = require("marko/dist/core-tags/components/init-components-tag.js");;
 
 /***/ }),
 
@@ -564,7 +564,7 @@ module.exports = marko/dist/core-tags/components/init-components-tag.js;
 /***/ ((module) => {
 
 "use strict";
-module.exports = marko/dist/core-tags/core/await/reorderer-renderer.js;
+module.exports = require("marko/dist/core-tags/core/await/reorderer-renderer.js");;
 
 /***/ }),
 
@@ -575,7 +575,7 @@ module.exports = marko/dist/core-tags/core/await/reorderer-renderer.js;
 /***/ ((module) => {
 
 "use strict";
-module.exports = marko/dist/runtime/components/renderer;
+module.exports = require("marko/dist/runtime/components/renderer");;
 
 /***/ }),
 
@@ -586,7 +586,7 @@ module.exports = marko/dist/runtime/components/renderer;
 /***/ ((module) => {
 
 "use strict";
-module.exports = marko/dist/runtime/helpers/render-tag;
+module.exports = require("marko/dist/runtime/helpers/render-tag");;
 
 /***/ }),
 
@@ -597,7 +597,7 @@ module.exports = marko/dist/runtime/helpers/render-tag;
 /***/ ((module) => {
 
 "use strict";
-module.exports = marko/dist/runtime/html;
+module.exports = require("marko/dist/runtime/html");;
 
 /***/ })
 

--- a/src/__tests__/fixtures/multiple-entries-plugin/__snapshots__/webpack5/server--main.js
+++ b/src/__tests__/fixtures/multiple-entries-plugin/__snapshots__/webpack5/server--main.js
@@ -609,8 +609,9 @@ module.exports = require("marko/dist/runtime/html");;
 /******/ 	// The require function
 /******/ 	function __webpack_require__(moduleId) {
 /******/ 		// Check if module is in cache
-/******/ 		if(__webpack_module_cache__[moduleId]) {
-/******/ 			return __webpack_module_cache__[moduleId].exports;
+/******/ 		var cachedModule = __webpack_module_cache__[moduleId];
+/******/ 		if (cachedModule !== undefined) {
+/******/ 			return cachedModule.exports;
 /******/ 		}
 /******/ 		// Create a new module (and put it into the cache)
 /******/ 		var module = __webpack_module_cache__[moduleId] = {

--- a/src/__tests__/fixtures/with-class-component-plugin-dynamic-bundle/__snapshots__/webpack4/browser-A--test_xbSt.A.js
+++ b/src/__tests__/fixtures/with-class-component-plugin-dynamic-bundle/__snapshots__/webpack4/browser-A--test_xbSt.A.js
@@ -218,7 +218,7 @@ window.$initComponents && $initComponents();
 
 "use strict";
 __webpack_require__.r(__webpack_exports__);
-/* harmony import */ var _test_marko_css_home_dpiercey_dev_github_marko_webpack_src_loader_index_ts_home_dpiercey_dev_github_marko_webpack_src_tests_fixtures_with_class_component_plugin_dynamic_bundle_test_marko_virtual_test_marko_css__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! ./test.marko.css = ./src/loader/index.ts!./src/__tests__/fixtures/with-class-component-plugin-dynamic-bundle/test.marko?virtual=./test.marko.css */ "./src/__tests__/fixtures/with-class-component-plugin-dynamic-bundle/test.marko.css!./=!./src/loader/index.ts!./src/__tests__/fixtures/with-class-component-plugin-dynamic-bundle/test.marko?virtual=./test.marko.css");
+/* harmony import */ var _test_marko_css_loader_index_ts_test_marko_virtual_test_marko_css__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! ./test.marko.css = ../../../loader/index.ts!./test.marko?virtual=./test.marko.css */ "./src/__tests__/fixtures/with-class-component-plugin-dynamic-bundle/test.marko.css!./=!./src/loader/index.ts!./src/__tests__/fixtures/with-class-component-plugin-dynamic-bundle/test.marko?virtual=./test.marko.css");
 
 
 /***/ }),

--- a/src/__tests__/fixtures/with-class-component-plugin-dynamic-bundle/__snapshots__/webpack4/browser-A--test_xbSt.A.js
+++ b/src/__tests__/fixtures/with-class-component-plugin-dynamic-bundle/__snapshots__/webpack4/browser-A--test_xbSt.A.js
@@ -246,7 +246,7 @@ __webpack_require__.r(__webpack_exports__);
 /*! no static exports found */
 /***/ (function(module, exports) {
 
-module.exports = marko/dist/runtime/components/defineComponent;
+module.exports = require("marko/dist/runtime/components/defineComponent");
 
 /***/ }),
 
@@ -257,7 +257,7 @@ module.exports = marko/dist/runtime/components/defineComponent;
 /*! no static exports found */
 /***/ (function(module, exports) {
 
-module.exports = marko/dist/runtime/components/registry-browser;
+module.exports = require("marko/dist/runtime/components/registry-browser");
 
 /***/ }),
 
@@ -268,7 +268,7 @@ module.exports = marko/dist/runtime/components/registry-browser;
 /*! no static exports found */
 /***/ (function(module, exports) {
 
-module.exports = marko/dist/runtime/components/renderer;
+module.exports = require("marko/dist/runtime/components/renderer");
 
 /***/ }),
 
@@ -279,7 +279,7 @@ module.exports = marko/dist/runtime/components/renderer;
 /*! no static exports found */
 /***/ (function(module, exports) {
 
-module.exports = marko/dist/runtime/vdom;
+module.exports = require("marko/dist/runtime/vdom");
 
 /***/ }),
 
@@ -290,7 +290,7 @@ module.exports = marko/dist/runtime/vdom;
 /*! no static exports found */
 /***/ (function(module, exports) {
 
-module.exports = marko/dist/runtime/vdom/helpers/v-element;
+module.exports = require("marko/dist/runtime/vdom/helpers/v-element");
 
 /***/ })
 

--- a/src/__tests__/fixtures/with-class-component-plugin-dynamic-bundle/__snapshots__/webpack4/browser-B--test_xbSt.B.js
+++ b/src/__tests__/fixtures/with-class-component-plugin-dynamic-bundle/__snapshots__/webpack4/browser-B--test_xbSt.B.js
@@ -218,7 +218,7 @@ window.$initComponents && $initComponents();
 
 "use strict";
 __webpack_require__.r(__webpack_exports__);
-/* harmony import */ var _test_marko_css_home_dpiercey_dev_github_marko_webpack_src_loader_index_ts_home_dpiercey_dev_github_marko_webpack_src_tests_fixtures_with_class_component_plugin_dynamic_bundle_test_marko_virtual_test_marko_css__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! ./test.marko.css = ./src/loader/index.ts!./src/__tests__/fixtures/with-class-component-plugin-dynamic-bundle/test.marko?virtual=./test.marko.css */ "./src/__tests__/fixtures/with-class-component-plugin-dynamic-bundle/test.marko.css!./=!./src/loader/index.ts!./src/__tests__/fixtures/with-class-component-plugin-dynamic-bundle/test.marko?virtual=./test.marko.css");
+/* harmony import */ var _test_marko_css_loader_index_ts_test_marko_virtual_test_marko_css__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! ./test.marko.css = ../../../loader/index.ts!./test.marko?virtual=./test.marko.css */ "./src/__tests__/fixtures/with-class-component-plugin-dynamic-bundle/test.marko.css!./=!./src/loader/index.ts!./src/__tests__/fixtures/with-class-component-plugin-dynamic-bundle/test.marko?virtual=./test.marko.css");
 
 
 /***/ }),

--- a/src/__tests__/fixtures/with-class-component-plugin-dynamic-bundle/__snapshots__/webpack4/browser-B--test_xbSt.B.js
+++ b/src/__tests__/fixtures/with-class-component-plugin-dynamic-bundle/__snapshots__/webpack4/browser-B--test_xbSt.B.js
@@ -246,7 +246,7 @@ __webpack_require__.r(__webpack_exports__);
 /*! no static exports found */
 /***/ (function(module, exports) {
 
-module.exports = marko/dist/runtime/components/defineComponent;
+module.exports = require("marko/dist/runtime/components/defineComponent");
 
 /***/ }),
 
@@ -257,7 +257,7 @@ module.exports = marko/dist/runtime/components/defineComponent;
 /*! no static exports found */
 /***/ (function(module, exports) {
 
-module.exports = marko/dist/runtime/components/registry-browser;
+module.exports = require("marko/dist/runtime/components/registry-browser");
 
 /***/ }),
 
@@ -268,7 +268,7 @@ module.exports = marko/dist/runtime/components/registry-browser;
 /*! no static exports found */
 /***/ (function(module, exports) {
 
-module.exports = marko/dist/runtime/components/renderer;
+module.exports = require("marko/dist/runtime/components/renderer");
 
 /***/ }),
 
@@ -279,7 +279,7 @@ module.exports = marko/dist/runtime/components/renderer;
 /*! no static exports found */
 /***/ (function(module, exports) {
 
-module.exports = marko/dist/runtime/vdom;
+module.exports = require("marko/dist/runtime/vdom");
 
 /***/ }),
 
@@ -290,7 +290,7 @@ module.exports = marko/dist/runtime/vdom;
 /*! no static exports found */
 /***/ (function(module, exports) {
 
-module.exports = marko/dist/runtime/vdom/helpers/v-element;
+module.exports = require("marko/dist/runtime/vdom/helpers/v-element");
 
 /***/ })
 

--- a/src/__tests__/fixtures/with-class-component-plugin-dynamic-bundle/__snapshots__/webpack4/browser-C--test_xbSt.C.js
+++ b/src/__tests__/fixtures/with-class-component-plugin-dynamic-bundle/__snapshots__/webpack4/browser-C--test_xbSt.C.js
@@ -218,7 +218,7 @@ window.$initComponents && $initComponents();
 
 "use strict";
 __webpack_require__.r(__webpack_exports__);
-/* harmony import */ var _test_marko_css_home_dpiercey_dev_github_marko_webpack_src_loader_index_ts_home_dpiercey_dev_github_marko_webpack_src_tests_fixtures_with_class_component_plugin_dynamic_bundle_test_marko_virtual_test_marko_css__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! ./test.marko.css = ./src/loader/index.ts!./src/__tests__/fixtures/with-class-component-plugin-dynamic-bundle/test.marko?virtual=./test.marko.css */ "./src/__tests__/fixtures/with-class-component-plugin-dynamic-bundle/test.marko.css!./=!./src/loader/index.ts!./src/__tests__/fixtures/with-class-component-plugin-dynamic-bundle/test.marko?virtual=./test.marko.css");
+/* harmony import */ var _test_marko_css_loader_index_ts_test_marko_virtual_test_marko_css__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! ./test.marko.css = ../../../loader/index.ts!./test.marko?virtual=./test.marko.css */ "./src/__tests__/fixtures/with-class-component-plugin-dynamic-bundle/test.marko.css!./=!./src/loader/index.ts!./src/__tests__/fixtures/with-class-component-plugin-dynamic-bundle/test.marko?virtual=./test.marko.css");
 
 
 /***/ }),

--- a/src/__tests__/fixtures/with-class-component-plugin-dynamic-bundle/__snapshots__/webpack4/browser-C--test_xbSt.C.js
+++ b/src/__tests__/fixtures/with-class-component-plugin-dynamic-bundle/__snapshots__/webpack4/browser-C--test_xbSt.C.js
@@ -246,7 +246,7 @@ __webpack_require__.r(__webpack_exports__);
 /*! no static exports found */
 /***/ (function(module, exports) {
 
-module.exports = marko/dist/runtime/components/defineComponent;
+module.exports = require("marko/dist/runtime/components/defineComponent");
 
 /***/ }),
 
@@ -257,7 +257,7 @@ module.exports = marko/dist/runtime/components/defineComponent;
 /*! no static exports found */
 /***/ (function(module, exports) {
 
-module.exports = marko/dist/runtime/components/registry-browser;
+module.exports = require("marko/dist/runtime/components/registry-browser");
 
 /***/ }),
 
@@ -268,7 +268,7 @@ module.exports = marko/dist/runtime/components/registry-browser;
 /*! no static exports found */
 /***/ (function(module, exports) {
 
-module.exports = marko/dist/runtime/components/renderer;
+module.exports = require("marko/dist/runtime/components/renderer");
 
 /***/ }),
 
@@ -279,7 +279,7 @@ module.exports = marko/dist/runtime/components/renderer;
 /*! no static exports found */
 /***/ (function(module, exports) {
 
-module.exports = marko/dist/runtime/vdom;
+module.exports = require("marko/dist/runtime/vdom");
 
 /***/ }),
 
@@ -290,7 +290,7 @@ module.exports = marko/dist/runtime/vdom;
 /*! no static exports found */
 /***/ (function(module, exports) {
 
-module.exports = marko/dist/runtime/vdom/helpers/v-element;
+module.exports = require("marko/dist/runtime/vdom/helpers/v-element");
 
 /***/ })
 

--- a/src/__tests__/fixtures/with-class-component-plugin-dynamic-bundle/__snapshots__/webpack4/server--main.js
+++ b/src/__tests__/fixtures/with-class-component-plugin-dynamic-bundle/__snapshots__/webpack4/server--main.js
@@ -325,7 +325,7 @@ __webpack_require__.r(__webpack_exports__);
 /*! no static exports found */
 /***/ (function(module, exports) {
 
-module.exports = http;
+module.exports = require("http");
 
 /***/ }),
 
@@ -336,7 +336,7 @@ module.exports = http;
 /*! no static exports found */
 /***/ (function(module, exports) {
 
-module.exports = marko/dist/core-tags/components/init-components-tag.js;
+module.exports = require("marko/dist/core-tags/components/init-components-tag.js");
 
 /***/ }),
 
@@ -347,7 +347,7 @@ module.exports = marko/dist/core-tags/components/init-components-tag.js;
 /*! no static exports found */
 /***/ (function(module, exports) {
 
-module.exports = marko/dist/core-tags/core/await/reorderer-renderer.js;
+module.exports = require("marko/dist/core-tags/core/await/reorderer-renderer.js");
 
 /***/ }),
 
@@ -358,7 +358,7 @@ module.exports = marko/dist/core-tags/core/await/reorderer-renderer.js;
 /*! no static exports found */
 /***/ (function(module, exports) {
 
-module.exports = marko/dist/runtime/components/renderer;
+module.exports = require("marko/dist/runtime/components/renderer");
 
 /***/ }),
 
@@ -369,7 +369,7 @@ module.exports = marko/dist/runtime/components/renderer;
 /*! no static exports found */
 /***/ (function(module, exports) {
 
-module.exports = marko/dist/runtime/helpers/render-tag;
+module.exports = require("marko/dist/runtime/helpers/render-tag");
 
 /***/ }),
 
@@ -380,7 +380,7 @@ module.exports = marko/dist/runtime/helpers/render-tag;
 /*! no static exports found */
 /***/ (function(module, exports) {
 
-module.exports = marko/dist/runtime/html;
+module.exports = require("marko/dist/runtime/html");
 
 /***/ })
 

--- a/src/__tests__/fixtures/with-class-component-plugin-dynamic-bundle/__snapshots__/webpack5/browser-A--test_xbSt.A.js
+++ b/src/__tests__/fixtures/with-class-component-plugin-dynamic-bundle/__snapshots__/webpack5/browser-A--test_xbSt.A.js
@@ -135,8 +135,9 @@ module.exports = require("marko/dist/runtime/vdom/helpers/v-element");;
 /******/ 	// The require function
 /******/ 	function __webpack_require__(moduleId) {
 /******/ 		// Check if module is in cache
-/******/ 		if(__webpack_module_cache__[moduleId]) {
-/******/ 			return __webpack_module_cache__[moduleId].exports;
+/******/ 		var cachedModule = __webpack_module_cache__[moduleId];
+/******/ 		if (cachedModule !== undefined) {
+/******/ 			return cachedModule.exports;
 /******/ 		}
 /******/ 		// Create a new module (and put it into the cache)
 /******/ 		var module = __webpack_module_cache__[moduleId] = {

--- a/src/__tests__/fixtures/with-class-component-plugin-dynamic-bundle/__snapshots__/webpack5/browser-A--test_xbSt.A.js
+++ b/src/__tests__/fixtures/with-class-component-plugin-dynamic-bundle/__snapshots__/webpack5/browser-A--test_xbSt.A.js
@@ -83,7 +83,7 @@ __webpack_require__.r(__webpack_exports__);
   \****************************************************************/
 /***/ ((module) => {
 
-module.exports = marko/dist/runtime/components/defineComponent;
+module.exports = require("marko/dist/runtime/components/defineComponent");;
 
 /***/ }),
 
@@ -93,7 +93,7 @@ module.exports = marko/dist/runtime/components/defineComponent;
   \*****************************************************************/
 /***/ ((module) => {
 
-module.exports = marko/dist/runtime/components/registry-browser;
+module.exports = require("marko/dist/runtime/components/registry-browser");;
 
 /***/ }),
 
@@ -103,7 +103,7 @@ module.exports = marko/dist/runtime/components/registry-browser;
   \*********************************************************/
 /***/ ((module) => {
 
-module.exports = marko/dist/runtime/components/renderer;
+module.exports = require("marko/dist/runtime/components/renderer");;
 
 /***/ }),
 
@@ -113,7 +113,7 @@ module.exports = marko/dist/runtime/components/renderer;
   \******************************************/
 /***/ ((module) => {
 
-module.exports = marko/dist/runtime/vdom;
+module.exports = require("marko/dist/runtime/vdom");;
 
 /***/ }),
 
@@ -123,7 +123,7 @@ module.exports = marko/dist/runtime/vdom;
   \************************************************************/
 /***/ ((module) => {
 
-module.exports = marko/dist/runtime/vdom/helpers/v-element;
+module.exports = require("marko/dist/runtime/vdom/helpers/v-element");;
 
 /***/ })
 

--- a/src/__tests__/fixtures/with-class-component-plugin-dynamic-bundle/__snapshots__/webpack5/browser-B--test_xbSt.B.js
+++ b/src/__tests__/fixtures/with-class-component-plugin-dynamic-bundle/__snapshots__/webpack5/browser-B--test_xbSt.B.js
@@ -135,8 +135,9 @@ module.exports = require("marko/dist/runtime/vdom/helpers/v-element");;
 /******/ 	// The require function
 /******/ 	function __webpack_require__(moduleId) {
 /******/ 		// Check if module is in cache
-/******/ 		if(__webpack_module_cache__[moduleId]) {
-/******/ 			return __webpack_module_cache__[moduleId].exports;
+/******/ 		var cachedModule = __webpack_module_cache__[moduleId];
+/******/ 		if (cachedModule !== undefined) {
+/******/ 			return cachedModule.exports;
 /******/ 		}
 /******/ 		// Create a new module (and put it into the cache)
 /******/ 		var module = __webpack_module_cache__[moduleId] = {

--- a/src/__tests__/fixtures/with-class-component-plugin-dynamic-bundle/__snapshots__/webpack5/browser-B--test_xbSt.B.js
+++ b/src/__tests__/fixtures/with-class-component-plugin-dynamic-bundle/__snapshots__/webpack5/browser-B--test_xbSt.B.js
@@ -83,7 +83,7 @@ __webpack_require__.r(__webpack_exports__);
   \****************************************************************/
 /***/ ((module) => {
 
-module.exports = marko/dist/runtime/components/defineComponent;
+module.exports = require("marko/dist/runtime/components/defineComponent");;
 
 /***/ }),
 
@@ -93,7 +93,7 @@ module.exports = marko/dist/runtime/components/defineComponent;
   \*****************************************************************/
 /***/ ((module) => {
 
-module.exports = marko/dist/runtime/components/registry-browser;
+module.exports = require("marko/dist/runtime/components/registry-browser");;
 
 /***/ }),
 
@@ -103,7 +103,7 @@ module.exports = marko/dist/runtime/components/registry-browser;
   \*********************************************************/
 /***/ ((module) => {
 
-module.exports = marko/dist/runtime/components/renderer;
+module.exports = require("marko/dist/runtime/components/renderer");;
 
 /***/ }),
 
@@ -113,7 +113,7 @@ module.exports = marko/dist/runtime/components/renderer;
   \******************************************/
 /***/ ((module) => {
 
-module.exports = marko/dist/runtime/vdom;
+module.exports = require("marko/dist/runtime/vdom");;
 
 /***/ }),
 
@@ -123,7 +123,7 @@ module.exports = marko/dist/runtime/vdom;
   \************************************************************/
 /***/ ((module) => {
 
-module.exports = marko/dist/runtime/vdom/helpers/v-element;
+module.exports = require("marko/dist/runtime/vdom/helpers/v-element");;
 
 /***/ })
 

--- a/src/__tests__/fixtures/with-class-component-plugin-dynamic-bundle/__snapshots__/webpack5/browser-C--test_xbSt.C.js
+++ b/src/__tests__/fixtures/with-class-component-plugin-dynamic-bundle/__snapshots__/webpack5/browser-C--test_xbSt.C.js
@@ -135,8 +135,9 @@ module.exports = require("marko/dist/runtime/vdom/helpers/v-element");;
 /******/ 	// The require function
 /******/ 	function __webpack_require__(moduleId) {
 /******/ 		// Check if module is in cache
-/******/ 		if(__webpack_module_cache__[moduleId]) {
-/******/ 			return __webpack_module_cache__[moduleId].exports;
+/******/ 		var cachedModule = __webpack_module_cache__[moduleId];
+/******/ 		if (cachedModule !== undefined) {
+/******/ 			return cachedModule.exports;
 /******/ 		}
 /******/ 		// Create a new module (and put it into the cache)
 /******/ 		var module = __webpack_module_cache__[moduleId] = {

--- a/src/__tests__/fixtures/with-class-component-plugin-dynamic-bundle/__snapshots__/webpack5/browser-C--test_xbSt.C.js
+++ b/src/__tests__/fixtures/with-class-component-plugin-dynamic-bundle/__snapshots__/webpack5/browser-C--test_xbSt.C.js
@@ -83,7 +83,7 @@ __webpack_require__.r(__webpack_exports__);
   \****************************************************************/
 /***/ ((module) => {
 
-module.exports = marko/dist/runtime/components/defineComponent;
+module.exports = require("marko/dist/runtime/components/defineComponent");;
 
 /***/ }),
 
@@ -93,7 +93,7 @@ module.exports = marko/dist/runtime/components/defineComponent;
   \*****************************************************************/
 /***/ ((module) => {
 
-module.exports = marko/dist/runtime/components/registry-browser;
+module.exports = require("marko/dist/runtime/components/registry-browser");;
 
 /***/ }),
 
@@ -103,7 +103,7 @@ module.exports = marko/dist/runtime/components/registry-browser;
   \*********************************************************/
 /***/ ((module) => {
 
-module.exports = marko/dist/runtime/components/renderer;
+module.exports = require("marko/dist/runtime/components/renderer");;
 
 /***/ }),
 
@@ -113,7 +113,7 @@ module.exports = marko/dist/runtime/components/renderer;
   \******************************************/
 /***/ ((module) => {
 
-module.exports = marko/dist/runtime/vdom;
+module.exports = require("marko/dist/runtime/vdom");;
 
 /***/ }),
 
@@ -123,7 +123,7 @@ module.exports = marko/dist/runtime/vdom;
   \************************************************************/
 /***/ ((module) => {
 
-module.exports = marko/dist/runtime/vdom/helpers/v-element;
+module.exports = require("marko/dist/runtime/vdom/helpers/v-element");;
 
 /***/ })
 

--- a/src/__tests__/fixtures/with-class-component-plugin-dynamic-bundle/__snapshots__/webpack5/server--main.js
+++ b/src/__tests__/fixtures/with-class-component-plugin-dynamic-bundle/__snapshots__/webpack5/server--main.js
@@ -296,8 +296,9 @@ module.exports = require("marko/dist/runtime/html");;
 /******/ 	// The require function
 /******/ 	function __webpack_require__(moduleId) {
 /******/ 		// Check if module is in cache
-/******/ 		if(__webpack_module_cache__[moduleId]) {
-/******/ 			return __webpack_module_cache__[moduleId].exports;
+/******/ 		var cachedModule = __webpack_module_cache__[moduleId];
+/******/ 		if (cachedModule !== undefined) {
+/******/ 			return cachedModule.exports;
 /******/ 		}
 /******/ 		// Create a new module (and put it into the cache)
 /******/ 		var module = __webpack_module_cache__[moduleId] = {

--- a/src/__tests__/fixtures/with-class-component-plugin-dynamic-bundle/__snapshots__/webpack5/server--main.js
+++ b/src/__tests__/fixtures/with-class-component-plugin-dynamic-bundle/__snapshots__/webpack5/server--main.js
@@ -240,7 +240,7 @@ module.exports = require("http");;
 /***/ ((module) => {
 
 "use strict";
-module.exports = marko/dist/core-tags/components/init-components-tag.js;
+module.exports = require("marko/dist/core-tags/components/init-components-tag.js");;
 
 /***/ }),
 
@@ -251,7 +251,7 @@ module.exports = marko/dist/core-tags/components/init-components-tag.js;
 /***/ ((module) => {
 
 "use strict";
-module.exports = marko/dist/core-tags/core/await/reorderer-renderer.js;
+module.exports = require("marko/dist/core-tags/core/await/reorderer-renderer.js");;
 
 /***/ }),
 
@@ -262,7 +262,7 @@ module.exports = marko/dist/core-tags/core/await/reorderer-renderer.js;
 /***/ ((module) => {
 
 "use strict";
-module.exports = marko/dist/runtime/components/renderer;
+module.exports = require("marko/dist/runtime/components/renderer");;
 
 /***/ }),
 
@@ -273,7 +273,7 @@ module.exports = marko/dist/runtime/components/renderer;
 /***/ ((module) => {
 
 "use strict";
-module.exports = marko/dist/runtime/helpers/render-tag;
+module.exports = require("marko/dist/runtime/helpers/render-tag");;
 
 /***/ }),
 
@@ -284,7 +284,7 @@ module.exports = marko/dist/runtime/helpers/render-tag;
 /***/ ((module) => {
 
 "use strict";
-module.exports = marko/dist/runtime/html;
+module.exports = require("marko/dist/runtime/html");;
 
 /***/ })
 

--- a/src/__tests__/fixtures/with-class-component-plugin/__snapshots__/webpack4/browser--test_ntnz.js
+++ b/src/__tests__/fixtures/with-class-component-plugin/__snapshots__/webpack4/browser--test_ntnz.js
@@ -244,7 +244,7 @@ __webpack_require__.r(__webpack_exports__);
 /*! no static exports found */
 /***/ (function(module, exports) {
 
-module.exports = marko/dist/runtime/components/defineComponent;
+module.exports = require("marko/dist/runtime/components/defineComponent");
 
 /***/ }),
 
@@ -255,7 +255,7 @@ module.exports = marko/dist/runtime/components/defineComponent;
 /*! no static exports found */
 /***/ (function(module, exports) {
 
-module.exports = marko/dist/runtime/components/registry-browser;
+module.exports = require("marko/dist/runtime/components/registry-browser");
 
 /***/ }),
 
@@ -266,7 +266,7 @@ module.exports = marko/dist/runtime/components/registry-browser;
 /*! no static exports found */
 /***/ (function(module, exports) {
 
-module.exports = marko/dist/runtime/components/renderer;
+module.exports = require("marko/dist/runtime/components/renderer");
 
 /***/ }),
 
@@ -277,7 +277,7 @@ module.exports = marko/dist/runtime/components/renderer;
 /*! no static exports found */
 /***/ (function(module, exports) {
 
-module.exports = marko/dist/runtime/vdom;
+module.exports = require("marko/dist/runtime/vdom");
 
 /***/ }),
 
@@ -288,7 +288,7 @@ module.exports = marko/dist/runtime/vdom;
 /*! no static exports found */
 /***/ (function(module, exports) {
 
-module.exports = marko/dist/runtime/vdom/helpers/v-element;
+module.exports = require("marko/dist/runtime/vdom/helpers/v-element");
 
 /***/ })
 

--- a/src/__tests__/fixtures/with-class-component-plugin/__snapshots__/webpack4/browser--test_ntnz.js
+++ b/src/__tests__/fixtures/with-class-component-plugin/__snapshots__/webpack4/browser--test_ntnz.js
@@ -216,7 +216,7 @@ window.$initComponents && $initComponents();
 
 "use strict";
 __webpack_require__.r(__webpack_exports__);
-/* harmony import */ var _test_marko_css_home_dpiercey_dev_github_marko_webpack_src_loader_index_ts_home_dpiercey_dev_github_marko_webpack_src_tests_fixtures_with_class_component_plugin_test_marko_virtual_test_marko_css__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! ./test.marko.css = ./src/loader/index.ts!./src/__tests__/fixtures/with-class-component-plugin/test.marko?virtual=./test.marko.css */ "./src/__tests__/fixtures/with-class-component-plugin/test.marko.css!./=!./src/loader/index.ts!./src/__tests__/fixtures/with-class-component-plugin/test.marko?virtual=./test.marko.css");
+/* harmony import */ var _test_marko_css_loader_index_ts_test_marko_virtual_test_marko_css__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! ./test.marko.css = ../../../loader/index.ts!./test.marko?virtual=./test.marko.css */ "./src/__tests__/fixtures/with-class-component-plugin/test.marko.css!./=!./src/loader/index.ts!./src/__tests__/fixtures/with-class-component-plugin/test.marko?virtual=./test.marko.css");
 
 
 /***/ }),

--- a/src/__tests__/fixtures/with-class-component-plugin/__snapshots__/webpack4/server--main.js
+++ b/src/__tests__/fixtures/with-class-component-plugin/__snapshots__/webpack4/server--main.js
@@ -318,7 +318,7 @@ __webpack_require__.r(__webpack_exports__);
 /*! no static exports found */
 /***/ (function(module, exports) {
 
-module.exports = http;
+module.exports = require("http");
 
 /***/ }),
 
@@ -329,7 +329,7 @@ module.exports = http;
 /*! no static exports found */
 /***/ (function(module, exports) {
 
-module.exports = marko/dist/core-tags/components/init-components-tag.js;
+module.exports = require("marko/dist/core-tags/components/init-components-tag.js");
 
 /***/ }),
 
@@ -340,7 +340,7 @@ module.exports = marko/dist/core-tags/components/init-components-tag.js;
 /*! no static exports found */
 /***/ (function(module, exports) {
 
-module.exports = marko/dist/core-tags/core/await/reorderer-renderer.js;
+module.exports = require("marko/dist/core-tags/core/await/reorderer-renderer.js");
 
 /***/ }),
 
@@ -351,7 +351,7 @@ module.exports = marko/dist/core-tags/core/await/reorderer-renderer.js;
 /*! no static exports found */
 /***/ (function(module, exports) {
 
-module.exports = marko/dist/runtime/components/renderer;
+module.exports = require("marko/dist/runtime/components/renderer");
 
 /***/ }),
 
@@ -362,7 +362,7 @@ module.exports = marko/dist/runtime/components/renderer;
 /*! no static exports found */
 /***/ (function(module, exports) {
 
-module.exports = marko/dist/runtime/helpers/render-tag;
+module.exports = require("marko/dist/runtime/helpers/render-tag");
 
 /***/ }),
 
@@ -373,7 +373,7 @@ module.exports = marko/dist/runtime/helpers/render-tag;
 /*! no static exports found */
 /***/ (function(module, exports) {
 
-module.exports = marko/dist/runtime/html;
+module.exports = require("marko/dist/runtime/html");
 
 /***/ })
 

--- a/src/__tests__/fixtures/with-class-component-plugin/__snapshots__/webpack5/browser--test_ntnz.js
+++ b/src/__tests__/fixtures/with-class-component-plugin/__snapshots__/webpack5/browser--test_ntnz.js
@@ -81,7 +81,7 @@ __webpack_require__.r(__webpack_exports__);
   \****************************************************************/
 /***/ ((module) => {
 
-module.exports = marko/dist/runtime/components/defineComponent;
+module.exports = require("marko/dist/runtime/components/defineComponent");;
 
 /***/ }),
 
@@ -91,7 +91,7 @@ module.exports = marko/dist/runtime/components/defineComponent;
   \*****************************************************************/
 /***/ ((module) => {
 
-module.exports = marko/dist/runtime/components/registry-browser;
+module.exports = require("marko/dist/runtime/components/registry-browser");;
 
 /***/ }),
 
@@ -101,7 +101,7 @@ module.exports = marko/dist/runtime/components/registry-browser;
   \*********************************************************/
 /***/ ((module) => {
 
-module.exports = marko/dist/runtime/components/renderer;
+module.exports = require("marko/dist/runtime/components/renderer");;
 
 /***/ }),
 
@@ -111,7 +111,7 @@ module.exports = marko/dist/runtime/components/renderer;
   \******************************************/
 /***/ ((module) => {
 
-module.exports = marko/dist/runtime/vdom;
+module.exports = require("marko/dist/runtime/vdom");;
 
 /***/ }),
 
@@ -121,7 +121,7 @@ module.exports = marko/dist/runtime/vdom;
   \************************************************************/
 /***/ ((module) => {
 
-module.exports = marko/dist/runtime/vdom/helpers/v-element;
+module.exports = require("marko/dist/runtime/vdom/helpers/v-element");;
 
 /***/ })
 

--- a/src/__tests__/fixtures/with-class-component-plugin/__snapshots__/webpack5/browser--test_ntnz.js
+++ b/src/__tests__/fixtures/with-class-component-plugin/__snapshots__/webpack5/browser--test_ntnz.js
@@ -133,8 +133,9 @@ module.exports = require("marko/dist/runtime/vdom/helpers/v-element");;
 /******/ 	// The require function
 /******/ 	function __webpack_require__(moduleId) {
 /******/ 		// Check if module is in cache
-/******/ 		if(__webpack_module_cache__[moduleId]) {
-/******/ 			return __webpack_module_cache__[moduleId].exports;
+/******/ 		var cachedModule = __webpack_module_cache__[moduleId];
+/******/ 		if (cachedModule !== undefined) {
+/******/ 			return cachedModule.exports;
 /******/ 		}
 /******/ 		// Create a new module (and put it into the cache)
 /******/ 		var module = __webpack_module_cache__[moduleId] = {

--- a/src/__tests__/fixtures/with-class-component-plugin/__snapshots__/webpack5/server--main.js
+++ b/src/__tests__/fixtures/with-class-component-plugin/__snapshots__/webpack5/server--main.js
@@ -233,7 +233,7 @@ module.exports = require("http");;
 /***/ ((module) => {
 
 "use strict";
-module.exports = marko/dist/core-tags/components/init-components-tag.js;
+module.exports = require("marko/dist/core-tags/components/init-components-tag.js");;
 
 /***/ }),
 
@@ -244,7 +244,7 @@ module.exports = marko/dist/core-tags/components/init-components-tag.js;
 /***/ ((module) => {
 
 "use strict";
-module.exports = marko/dist/core-tags/core/await/reorderer-renderer.js;
+module.exports = require("marko/dist/core-tags/core/await/reorderer-renderer.js");;
 
 /***/ }),
 
@@ -255,7 +255,7 @@ module.exports = marko/dist/core-tags/core/await/reorderer-renderer.js;
 /***/ ((module) => {
 
 "use strict";
-module.exports = marko/dist/runtime/components/renderer;
+module.exports = require("marko/dist/runtime/components/renderer");;
 
 /***/ }),
 
@@ -266,7 +266,7 @@ module.exports = marko/dist/runtime/components/renderer;
 /***/ ((module) => {
 
 "use strict";
-module.exports = marko/dist/runtime/helpers/render-tag;
+module.exports = require("marko/dist/runtime/helpers/render-tag");;
 
 /***/ }),
 
@@ -277,7 +277,7 @@ module.exports = marko/dist/runtime/helpers/render-tag;
 /***/ ((module) => {
 
 "use strict";
-module.exports = marko/dist/runtime/html;
+module.exports = require("marko/dist/runtime/html");;
 
 /***/ })
 

--- a/src/__tests__/fixtures/with-class-component-plugin/__snapshots__/webpack5/server--main.js
+++ b/src/__tests__/fixtures/with-class-component-plugin/__snapshots__/webpack5/server--main.js
@@ -289,8 +289,9 @@ module.exports = require("marko/dist/runtime/html");;
 /******/ 	// The require function
 /******/ 	function __webpack_require__(moduleId) {
 /******/ 		// Check if module is in cache
-/******/ 		if(__webpack_module_cache__[moduleId]) {
-/******/ 			return __webpack_module_cache__[moduleId].exports;
+/******/ 		var cachedModule = __webpack_module_cache__[moduleId];
+/******/ 		if (cachedModule !== undefined) {
+/******/ 			return cachedModule.exports;
 /******/ 		}
 /******/ 		// Create a new module (and put it into the cache)
 /******/ 		var module = __webpack_module_cache__[moduleId] = {

--- a/src/__tests__/fixtures/with-css-extract/__snapshots__/webpack4/main.js
+++ b/src/__tests__/fixtures/with-css-extract/__snapshots__/webpack4/main.js
@@ -184,7 +184,7 @@ __webpack_require__.r(__webpack_exports__);
 /*! no static exports found */
 /***/ (function(module, exports) {
 
-module.exports = marko/dist/runtime/components/defineComponent;
+module.exports = require("marko/dist/runtime/components/defineComponent");
 
 /***/ }),
 
@@ -195,7 +195,7 @@ module.exports = marko/dist/runtime/components/defineComponent;
 /*! no static exports found */
 /***/ (function(module, exports) {
 
-module.exports = marko/dist/runtime/components/registry-browser;
+module.exports = require("marko/dist/runtime/components/registry-browser");
 
 /***/ }),
 
@@ -206,7 +206,7 @@ module.exports = marko/dist/runtime/components/registry-browser;
 /*! no static exports found */
 /***/ (function(module, exports) {
 
-module.exports = marko/dist/runtime/components/renderer;
+module.exports = require("marko/dist/runtime/components/renderer");
 
 /***/ }),
 
@@ -217,7 +217,7 @@ module.exports = marko/dist/runtime/components/renderer;
 /*! no static exports found */
 /***/ (function(module, exports) {
 
-module.exports = marko/dist/runtime/vdom;
+module.exports = require("marko/dist/runtime/vdom");
 
 /***/ }),
 
@@ -228,7 +228,7 @@ module.exports = marko/dist/runtime/vdom;
 /*! no static exports found */
 /***/ (function(module, exports) {
 
-module.exports = marko/dist/runtime/vdom/helpers/v-element;
+module.exports = require("marko/dist/runtime/vdom/helpers/v-element");
 
 /***/ })
 

--- a/src/__tests__/fixtures/with-css-extract/__snapshots__/webpack4/main.js
+++ b/src/__tests__/fixtures/with-css-extract/__snapshots__/webpack4/main.js
@@ -172,7 +172,7 @@ _marko_template.Component = marko_dist_runtime_components_defineComponent__WEBPA
 
 "use strict";
 __webpack_require__.r(__webpack_exports__);
-/* harmony import */ var _test_marko_css_home_dpiercey_dev_github_marko_webpack_src_loader_index_ts_home_dpiercey_dev_github_marko_webpack_src_tests_fixtures_with_css_extract_test_marko_virtual_test_marko_css__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! ./test.marko.css = ./src/loader/index.ts!./src/__tests__/fixtures/with-css-extract/test.marko?virtual=./test.marko.css */ "./src/__tests__/fixtures/with-css-extract/test.marko.css!./=!./src/loader/index.ts!./src/__tests__/fixtures/with-css-extract/test.marko?virtual=./test.marko.css");
+/* harmony import */ var _test_marko_css_loader_index_ts_test_marko_virtual_test_marko_css__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! ./test.marko.css = ../../../loader/index.ts!./test.marko?virtual=./test.marko.css */ "./src/__tests__/fixtures/with-css-extract/test.marko.css!./=!./src/loader/index.ts!./src/__tests__/fixtures/with-css-extract/test.marko?virtual=./test.marko.css");
 
 
 /***/ }),

--- a/src/__tests__/fixtures/with-css-extract/__snapshots__/webpack5/main.js
+++ b/src/__tests__/fixtures/with-css-extract/__snapshots__/webpack5/main.js
@@ -105,8 +105,9 @@ module.exports = require("marko/dist/runtime/vdom/helpers/v-element");;
 /******/ 	// The require function
 /******/ 	function __webpack_require__(moduleId) {
 /******/ 		// Check if module is in cache
-/******/ 		if(__webpack_module_cache__[moduleId]) {
-/******/ 			return __webpack_module_cache__[moduleId].exports;
+/******/ 		var cachedModule = __webpack_module_cache__[moduleId];
+/******/ 		if (cachedModule !== undefined) {
+/******/ 			return cachedModule.exports;
 /******/ 		}
 /******/ 		// Create a new module (and put it into the cache)
 /******/ 		var module = __webpack_module_cache__[moduleId] = {

--- a/src/__tests__/fixtures/with-css-extract/__snapshots__/webpack5/main.js
+++ b/src/__tests__/fixtures/with-css-extract/__snapshots__/webpack5/main.js
@@ -53,7 +53,7 @@ _marko_template.Component = marko_dist_runtime_components_defineComponent__WEBPA
   \****************************************************************/
 /***/ ((module) => {
 
-module.exports = marko/dist/runtime/components/defineComponent;
+module.exports = require("marko/dist/runtime/components/defineComponent");;
 
 /***/ }),
 
@@ -63,7 +63,7 @@ module.exports = marko/dist/runtime/components/defineComponent;
   \*****************************************************************/
 /***/ ((module) => {
 
-module.exports = marko/dist/runtime/components/registry-browser;
+module.exports = require("marko/dist/runtime/components/registry-browser");;
 
 /***/ }),
 
@@ -73,7 +73,7 @@ module.exports = marko/dist/runtime/components/registry-browser;
   \*********************************************************/
 /***/ ((module) => {
 
-module.exports = marko/dist/runtime/components/renderer;
+module.exports = require("marko/dist/runtime/components/renderer");;
 
 /***/ }),
 
@@ -83,7 +83,7 @@ module.exports = marko/dist/runtime/components/renderer;
   \******************************************/
 /***/ ((module) => {
 
-module.exports = marko/dist/runtime/vdom;
+module.exports = require("marko/dist/runtime/vdom");;
 
 /***/ }),
 
@@ -93,7 +93,7 @@ module.exports = marko/dist/runtime/vdom;
   \************************************************************/
 /***/ ((module) => {
 
-module.exports = marko/dist/runtime/vdom/helpers/v-element;
+module.exports = require("marko/dist/runtime/vdom/helpers/v-element");;
 
 /***/ })
 

--- a/src/__tests__/fixtures/with-css/__snapshots__/webpack4/main.js
+++ b/src/__tests__/fixtures/with-css/__snapshots__/webpack4/main.js
@@ -565,7 +565,7 @@ _marko_template.Component = marko_dist_runtime_components_defineComponent__WEBPA
 
 "use strict";
 __webpack_require__.r(__webpack_exports__);
-/* harmony import */ var _test_marko_css_home_dpiercey_dev_github_marko_webpack_src_loader_index_ts_home_dpiercey_dev_github_marko_webpack_src_tests_fixtures_with_css_test_marko_virtual_test_marko_css__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! ./test.marko.css = ./src/loader/index.ts!./src/__tests__/fixtures/with-css/test.marko?virtual=./test.marko.css */ "./src/__tests__/fixtures/with-css/test.marko.css!./=!./src/loader/index.ts!./src/__tests__/fixtures/with-css/test.marko?virtual=./test.marko.css");
+/* harmony import */ var _test_marko_css_loader_index_ts_test_marko_virtual_test_marko_css__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! ./test.marko.css = ../../../loader/index.ts!./test.marko?virtual=./test.marko.css */ "./src/__tests__/fixtures/with-css/test.marko.css!./=!./src/loader/index.ts!./src/__tests__/fixtures/with-css/test.marko?virtual=./test.marko.css");
 
 
 /***/ }),

--- a/src/__tests__/fixtures/with-css/__snapshots__/webpack4/main.js
+++ b/src/__tests__/fixtures/with-css/__snapshots__/webpack4/main.js
@@ -577,7 +577,7 @@ __webpack_require__.r(__webpack_exports__);
 /*! no static exports found */
 /***/ (function(module, exports) {
 
-module.exports = marko/dist/runtime/components/defineComponent;
+module.exports = require("marko/dist/runtime/components/defineComponent");
 
 /***/ }),
 
@@ -588,7 +588,7 @@ module.exports = marko/dist/runtime/components/defineComponent;
 /*! no static exports found */
 /***/ (function(module, exports) {
 
-module.exports = marko/dist/runtime/components/registry-browser;
+module.exports = require("marko/dist/runtime/components/registry-browser");
 
 /***/ }),
 
@@ -599,7 +599,7 @@ module.exports = marko/dist/runtime/components/registry-browser;
 /*! no static exports found */
 /***/ (function(module, exports) {
 
-module.exports = marko/dist/runtime/components/renderer;
+module.exports = require("marko/dist/runtime/components/renderer");
 
 /***/ }),
 
@@ -610,7 +610,7 @@ module.exports = marko/dist/runtime/components/renderer;
 /*! no static exports found */
 /***/ (function(module, exports) {
 
-module.exports = marko/dist/runtime/vdom;
+module.exports = require("marko/dist/runtime/vdom");
 
 /***/ }),
 
@@ -621,7 +621,7 @@ module.exports = marko/dist/runtime/vdom;
 /*! no static exports found */
 /***/ (function(module, exports) {
 
-module.exports = marko/dist/runtime/vdom/helpers/v-element;
+module.exports = require("marko/dist/runtime/vdom/helpers/v-element");
 
 /***/ })
 

--- a/src/__tests__/fixtures/with-css/__snapshots__/webpack5/main.js
+++ b/src/__tests__/fixtures/with-css/__snapshots__/webpack5/main.js
@@ -522,8 +522,9 @@ module.exports = require("marko/dist/runtime/vdom/helpers/v-element");;
 /******/ 	// The require function
 /******/ 	function __webpack_require__(moduleId) {
 /******/ 		// Check if module is in cache
-/******/ 		if(__webpack_module_cache__[moduleId]) {
-/******/ 			return __webpack_module_cache__[moduleId].exports;
+/******/ 		var cachedModule = __webpack_module_cache__[moduleId];
+/******/ 		if (cachedModule !== undefined) {
+/******/ 			return cachedModule.exports;
 /******/ 		}
 /******/ 		// Create a new module (and put it into the cache)
 /******/ 		var module = __webpack_module_cache__[moduleId] = {

--- a/src/__tests__/fixtures/with-css/__snapshots__/webpack5/main.js
+++ b/src/__tests__/fixtures/with-css/__snapshots__/webpack5/main.js
@@ -459,7 +459,7 @@ _marko_template.Component = marko_dist_runtime_components_defineComponent__WEBPA
 /***/ ((__unused_webpack_module, __webpack_exports__, __webpack_require__) => {
 
 __webpack_require__.r(__webpack_exports__);
-/* harmony import */ var _test_marko_css_home_dpiercey_dev_github_marko_webpack_src_loader_index_ts_home_dpiercey_dev_github_marko_webpack_src_tests_fixtures_with_css_test_marko_virtual_test_marko_css__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! ./test.marko.css!=!./src/loader/index.ts!./src/__tests__/fixtures/with-css/test.marko?virtual=./test.marko.css */ "./src/__tests__/fixtures/with-css/test.marko.css!=!./src/loader/index.ts!./src/__tests__/fixtures/with-css/test.marko?virtual=./test.marko.css");
+/* harmony import */ var _test_marko_css_loader_index_ts_test_marko_virtual_test_marko_css__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! ./test.marko.css!=!../../../loader/index.ts!./test.marko?virtual=./test.marko.css */ "./src/__tests__/fixtures/with-css/test.marko.css!=!./src/loader/index.ts!./src/__tests__/fixtures/with-css/test.marko?virtual=./test.marko.css");
 
 
 /***/ }),

--- a/src/__tests__/fixtures/with-css/__snapshots__/webpack5/main.js
+++ b/src/__tests__/fixtures/with-css/__snapshots__/webpack5/main.js
@@ -470,7 +470,7 @@ __webpack_require__.r(__webpack_exports__);
   \****************************************************************/
 /***/ ((module) => {
 
-module.exports = marko/dist/runtime/components/defineComponent;
+module.exports = require("marko/dist/runtime/components/defineComponent");;
 
 /***/ }),
 
@@ -480,7 +480,7 @@ module.exports = marko/dist/runtime/components/defineComponent;
   \*****************************************************************/
 /***/ ((module) => {
 
-module.exports = marko/dist/runtime/components/registry-browser;
+module.exports = require("marko/dist/runtime/components/registry-browser");;
 
 /***/ }),
 
@@ -490,7 +490,7 @@ module.exports = marko/dist/runtime/components/registry-browser;
   \*********************************************************/
 /***/ ((module) => {
 
-module.exports = marko/dist/runtime/components/renderer;
+module.exports = require("marko/dist/runtime/components/renderer");;
 
 /***/ }),
 
@@ -500,7 +500,7 @@ module.exports = marko/dist/runtime/components/renderer;
   \******************************************/
 /***/ ((module) => {
 
-module.exports = marko/dist/runtime/vdom;
+module.exports = require("marko/dist/runtime/vdom");;
 
 /***/ }),
 
@@ -510,7 +510,7 @@ module.exports = marko/dist/runtime/vdom;
   \************************************************************/
 /***/ ((module) => {
 
-module.exports = marko/dist/runtime/vdom/helpers/v-element;
+module.exports = require("marko/dist/runtime/vdom/helpers/v-element");;
 
 /***/ })
 

--- a/src/__tests__/fixtures/with-public-path/__snapshots__/webpack4/server--main.js
+++ b/src/__tests__/fixtures/with-public-path/__snapshots__/webpack4/server--main.js
@@ -278,7 +278,7 @@ __webpack_require__.r(__webpack_exports__);
 /*! no static exports found */
 /***/ (function(module, exports) {
 
-module.exports = http;
+module.exports = require("http");
 
 /***/ }),
 
@@ -289,7 +289,7 @@ module.exports = http;
 /*! no static exports found */
 /***/ (function(module, exports) {
 
-module.exports = marko/dist/core-tags/components/init-components-tag.js;
+module.exports = require("marko/dist/core-tags/components/init-components-tag.js");
 
 /***/ }),
 
@@ -300,7 +300,7 @@ module.exports = marko/dist/core-tags/components/init-components-tag.js;
 /*! no static exports found */
 /***/ (function(module, exports) {
 
-module.exports = marko/dist/core-tags/core/await/reorderer-renderer.js;
+module.exports = require("marko/dist/core-tags/core/await/reorderer-renderer.js");
 
 /***/ }),
 
@@ -311,7 +311,7 @@ module.exports = marko/dist/core-tags/core/await/reorderer-renderer.js;
 /*! no static exports found */
 /***/ (function(module, exports) {
 
-module.exports = marko/dist/runtime/components/renderer;
+module.exports = require("marko/dist/runtime/components/renderer");
 
 /***/ }),
 
@@ -322,7 +322,7 @@ module.exports = marko/dist/runtime/components/renderer;
 /*! no static exports found */
 /***/ (function(module, exports) {
 
-module.exports = marko/dist/runtime/helpers/render-tag;
+module.exports = require("marko/dist/runtime/helpers/render-tag");
 
 /***/ }),
 
@@ -333,7 +333,7 @@ module.exports = marko/dist/runtime/helpers/render-tag;
 /*! no static exports found */
 /***/ (function(module, exports) {
 
-module.exports = marko/dist/runtime/html;
+module.exports = require("marko/dist/runtime/html");
 
 /***/ })
 

--- a/src/__tests__/fixtures/with-public-path/__snapshots__/webpack5/server--main.js
+++ b/src/__tests__/fixtures/with-public-path/__snapshots__/webpack5/server--main.js
@@ -247,8 +247,9 @@ module.exports = require("marko/dist/runtime/html");;
 /******/ 	// The require function
 /******/ 	function __webpack_require__(moduleId) {
 /******/ 		// Check if module is in cache
-/******/ 		if(__webpack_module_cache__[moduleId]) {
-/******/ 			return __webpack_module_cache__[moduleId].exports;
+/******/ 		var cachedModule = __webpack_module_cache__[moduleId];
+/******/ 		if (cachedModule !== undefined) {
+/******/ 			return cachedModule.exports;
 /******/ 		}
 /******/ 		// Create a new module (and put it into the cache)
 /******/ 		var module = __webpack_module_cache__[moduleId] = {

--- a/src/__tests__/fixtures/with-public-path/__snapshots__/webpack5/server--main.js
+++ b/src/__tests__/fixtures/with-public-path/__snapshots__/webpack5/server--main.js
@@ -191,7 +191,7 @@ module.exports = require("http");;
 /***/ ((module) => {
 
 "use strict";
-module.exports = marko/dist/core-tags/components/init-components-tag.js;
+module.exports = require("marko/dist/core-tags/components/init-components-tag.js");;
 
 /***/ }),
 
@@ -202,7 +202,7 @@ module.exports = marko/dist/core-tags/components/init-components-tag.js;
 /***/ ((module) => {
 
 "use strict";
-module.exports = marko/dist/core-tags/core/await/reorderer-renderer.js;
+module.exports = require("marko/dist/core-tags/core/await/reorderer-renderer.js");;
 
 /***/ }),
 
@@ -213,7 +213,7 @@ module.exports = marko/dist/core-tags/core/await/reorderer-renderer.js;
 /***/ ((module) => {
 
 "use strict";
-module.exports = marko/dist/runtime/components/renderer;
+module.exports = require("marko/dist/runtime/components/renderer");;
 
 /***/ }),
 
@@ -224,7 +224,7 @@ module.exports = marko/dist/runtime/components/renderer;
 /***/ ((module) => {
 
 "use strict";
-module.exports = marko/dist/runtime/helpers/render-tag;
+module.exports = require("marko/dist/runtime/helpers/render-tag");;
 
 /***/ }),
 
@@ -235,7 +235,7 @@ module.exports = marko/dist/runtime/helpers/render-tag;
 /***/ ((module) => {
 
 "use strict";
-module.exports = marko/dist/runtime/html;
+module.exports = require("marko/dist/runtime/html");;
 
 /***/ })
 

--- a/src/__tests__/util/compilation.ts
+++ b/src/__tests__/util/compilation.ts
@@ -43,7 +43,20 @@ function extendConfig(config: webpack.Configuration) {
   // but we'll disable sourcemaps unless the test has specifically opted in
   config.mode = config.mode || "development";
   config.devtool = config.devtool || false;
-  config.externals = [/^[^./!]/]; // excludes node_modules
+
+  // excludes node_modules
+  // the function signature differs between webpack 4/5
+  config.externals = [
+    (...args) => {
+      const isWebpack4 = typeof args[2] === "function";
+      const request = isWebpack4 ? args[1] : args[0].request;
+      const callback = isWebpack4 ? args[2] : args[1];
+      if (/^[^./!]/.test(request)) {
+        return callback(null, request, "commonjs2");
+      }
+      callback();
+    }
+  ];
 
   return config;
 }

--- a/src/loader/index.ts
+++ b/src/loader/index.ts
@@ -206,10 +206,14 @@ export default async function (
           deps.push(importStr(dep));
         } else {
           // inline content, we'll create a virtual dependency.
-          const virtualPath = `${resourcePath}?virtual=${dep.virtualPath}`;
-          virtualSources.set(virtualPath, { code: dep.code });
+          const absoluteVirtualPath = `${resourcePath}?virtual=${dep.virtualPath}`;
+          const relativeVirtualPath = `${basePath}?virtual=${dep.virtualPath}`;
+          const relativeLoaderPath = path.relative(this.context, __filename);
+          virtualSources.set(absoluteVirtualPath, { code: dep.code });
           deps.push(
-            importStr(`${dep.virtualPath}!=!${__filename}!${virtualPath}`)
+            importStr(
+              `${dep.virtualPath}!=!${relativeLoaderPath}!${relativeVirtualPath}`
+            )
           );
         }
       }


### PR DESCRIPTION


When pulling down the latest code, there were snapshot failures due to the inclusion of an absolute path for virtual dependencies and a new version of webpack being pulled in which slightly changed its runtime.

It seems that the `npm:webpack@^5.0.0` does not respect the version in `package-lock.json` with the default install command (though it does with `npm ci`).  

We may want to consider switching `webpack5` to `webpack` and then add a `webpack4` alias that is pinned to the current 4.x release as that's getting less updates, but this PR does not do that.

