### PR TITLE
fix: regression w/ templates not marked as entry

### DIFF
--- a/src/plugin/index.ts
+++ b/src/plugin/index.ts
@@ -71,11 +71,11 @@ export default class MarkoWebpackPlugin {
               const { issuer } = data.contextInfo;
               if (
                 data.request.endsWith(".marko") &&
-                issuer &&
-                !(
-                  issuer.endsWith(".marko") ||
-                  /[/\\]node_modules[/\\]/.test(issuer)
-                )
+                (!issuer ||
+                  !(
+                    issuer.endsWith(".marko") ||
+                    /[/\\]node_modules[/\\]/.test(issuer)
+                  ))
               ) {
                 data.request = `${data.request}?server-entry`;
               }


### PR DESCRIPTION
## Description

Fixes a regression caused by #536635123902d2b5d32ab70accd7d95fa6bec14b where some Marko files were not being treated as entry files.

resolves #84