### PR TITLE
fix: ignore .d.ts in watch files

### DIFF
--- a/src/loader/index.ts
+++ b/src/loader/index.ts
@@ -240,7 +240,7 @@ function getTrailingContent(
         templateFileName === "index"
           ? ""
           : `${escapeRegExp(templateFileName)}\\.`
-      }(?:${missingDeps.join("|")})\\.[^\\${path.sep}]+$/)`;
+      }(?:${missingDeps.join("|")})\\.\\w+$/)`;
     }
   }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Fixes issue where files like `component-browser.d.ts` will attempt to be loaded by Webpack.

<!--- Describe your changes in detail.  Include the package name if applicable. -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

<!--- If it fixes an open issue, please link to the issue here. -->

## Screenshots (if appropriate):

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.

<!--
Disclaimer: Contributions via GitHub pull requests are gladly accepted from their original author. Along with any pull requests, please state that the contribution is your original work and that you license the work to the project under the project's open source license. Whether or not you state this explicitly, by submitting any copyrighted material via pull request, email, or other means you agree to license the material under the project's open source license and warrant that you have the legal authority to do so.
-->
