### PR TITLE
fix: avoid loading dts files

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "@marko/webpack",
-      "version": "9.3.3",
+      "version": "9.3.6",
       "license": "MIT",
       "dependencies": {
         "escape-string-regexp": "^4.0.0",

--- a/src/loader/index.ts
+++ b/src/loader/index.ts
@@ -49,14 +49,15 @@ const WATCH_MISSING_FILES = [
     basename: "component-browser",
     has(meta: MarkoMeta): boolean {
       return Boolean(
-        meta.deps &&
-          meta.deps.some(
-            dep =>
-              getBasenameWithoutExt(
-                (typeof dep === "object" && dep.virtualPath) ||
-                  ((dep as unknown) as string)
-              ) === this.basename
-          )
+        meta.component ||
+          (meta.deps &&
+            meta.deps.some(
+              dep =>
+                getBasenameWithoutExt(
+                  (typeof dep === "object" && dep.virtualPath) ||
+                    ((dep as unknown) as string)
+                ) === this.basename
+            ))
       );
     }
   }
@@ -236,11 +237,11 @@ function getTrailingContent(
 
     if (missingDeps.length) {
       const templateFileName = getBasenameWithoutExt(resource);
-      result += `\nrequire.context(".", false, /\\${path.sep}${
+      result += `\nrequire.context(".", false, /\\/${
         templateFileName === "index"
           ? ""
           : `${escapeRegExp(templateFileName)}\\.`
-      }(?:${missingDeps.join("|")})\\.\\w+$/)`;
+      }(?:${missingDeps.join("|")})\\.[^d]\\w*$/)`;
     }
   }
 


### PR DESCRIPTION
## Description

* Avoids loading any `.d.*` files when watching for missing component files.
* Fixes check to see if we should be scanning for `component-browser.*` files.